### PR TITLE
improve errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ dependencies = [
  "common",
  "glob-match",
  "graphql-parser",
+ "http 0.2.12",
  "indexmap 2.5.0",
  "insta",
  "ndc-sdk",
@@ -1206,6 +1207,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
 ]

--- a/crates/ndc-graphql/Cargo.toml
+++ b/crates/ndc-graphql/Cargo.toml
@@ -8,6 +8,7 @@ async-trait = "0.1.78"
 common = { path = "../common" }
 glob-match = "0.2.1"
 graphql-parser = "0.4.0"
+http = "0.2"
 indexmap = "2.1.0"
 ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs", tag = "v0.4.0", package = "ndc-sdk", features = [
   "rustls",
@@ -19,6 +20,7 @@ reqwest = { version = "0.12.3", features = [
 ], default-features = false }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
+thiserror = "1.0.64"
 tokio = "1.36.0"
 tracing = "0.1.40"
 

--- a/crates/ndc-graphql/src/connector/state.rs
+++ b/crates/ndc-graphql/src/connector/state.rs
@@ -1,6 +1,5 @@
-use std::{error::Error, sync::Arc};
-
 use common::{client::get_http_client, config::ServerConfig};
+use std::sync::Arc;
 use tokio::sync::RwLock;
 
 #[derive(Debug, Clone)]
@@ -17,7 +16,7 @@ impl ServerState {
             client: Arc::new(RwLock::new(client)),
         }
     }
-    pub async fn client(&self, config: &ServerConfig) -> Result<reqwest::Client, Box<dyn Error>> {
+    pub async fn client(&self, config: &ServerConfig) -> Result<reqwest::Client, reqwest::Error> {
         if let Some(client) = &*self.client.read().await {
             Ok(client.clone())
         } else {

--- a/crates/ndc-graphql/tests/query_builder.rs
+++ b/crates/ndc-graphql/tests/query_builder.rs
@@ -113,9 +113,5 @@ fn test_capabilities() {
 
 #[test]
 fn configuration_schema() {
-    assert_snapshot!(
-        "Configuration JSON Schema",
-        serde_json::to_string_pretty(&schema_for!(ServerConfigFile))
-            .expect("Should serialize schema to json")
-    )
+    assert_json_snapshot!("Configuration JSON Schema", schema_for!(ServerConfigFile))
 }


### PR DESCRIPTION
Improve errors:
last release worked around the removal of the `Other` error variants by changing those error types. This resulted in previous 500 errors being exposed as 422.

This PR reverts that behavior.

We also introduce `thiserror` to simplify generating error types 