### PR TITLE
feat: support request-level arguments and upgrade ndc-spec v2.10.0

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -7,7 +7,7 @@ jobs:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           # this defaults to "-D warnings", making warnings fail the entire build.
@@ -21,7 +21,7 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # Ensure rustfmt is installed and setup problem matcher
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -23,7 +23,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -41,7 +41,7 @@ jobs:
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ startsWith(github.ref, 'refs/tags/v') }}
@@ -79,7 +79,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: install protoc
         uses: arduino/setup-protoc@v3
@@ -151,7 +151,7 @@ jobs:
         with:
           rustflags: "" # defaults to "-D warnings", set to empty string to allow warnings
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
           
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -6,7 +6,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           # this defaults to "-D warnings", making warnings fail the entire build.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0]
+
+- Upgrade ndc-spec v0.2.10 and ndc-rust-sdk
+- Support request-level arguments
+
 ## [0.2.3]
 
 - Patch release for v0.2.1 and v0.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,37 +98,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
+name = "async-compression"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+checksum = "977eb15ea9efd848bb8a4a1a2500347ed7f0bf794edf0dc3ddcf439f43d36b23"
 dependencies = [
- "async-stream-impl",
+ "compression-codecs",
+ "compression-core",
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
+ "tokio",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -138,18 +135,19 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -161,47 +159,54 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 0.1.2",
+ "sync_wrapper",
  "tokio",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http",
+ "http-body",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-extra"
-version = "0.8.0"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab90e7b70bea63a153137162affb6a0bce26b584c24a4c7885509783e2cf30b"
+checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
 dependencies = [
  "axum",
  "axum-core",
  "bytes",
+ "fastrand",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http",
+ "http-body",
+ "http-body-util",
  "mime",
+ "multer",
  "pin-project-lite",
  "serde",
- "tokio",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -223,21 +228,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -273,6 +266,8 @@ version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -366,12 +361,31 @@ dependencies = [
  "graphql-parser",
  "graphql_client",
  "ndc-models",
- "reqwest 0.12.20",
+ "reqwest",
  "schemars 0.8.22",
  "serde",
  "serde_json",
  "tokio",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "485abf41ac0c8047c07c87c72c8fb3eb5197f6e9d7ded615dfd1a00ae00a0f64"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
 
 [[package]]
 name = "console"
@@ -396,6 +410,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,21 +433,6 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "darling"
@@ -577,6 +586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -676,12 +686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
 name = "glob-match"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,17 +764,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.9.0",
+ "http",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util",
@@ -809,17 +813,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -831,23 +824,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http",
 ]
 
 [[package]]
@@ -858,16 +840,10 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -883,30 +859,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -914,9 +866,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -930,40 +884,44 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
- "hyper 1.6.0",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.28",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots",
 ]
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 0.14.32",
+ "hyper",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-io-timeout",
+ "tower-service",
 ]
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper 0.14.32",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -972,22 +930,24 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "hyper 1.6.0",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1140,20 +1100,21 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "insta"
-version = "1.43.1"
+version = "1.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
 dependencies = [
  "console",
  "globset",
@@ -1161,6 +1122,17 @@ dependencies = [
  "serde",
  "similar",
  "walkdir",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1199,6 +1171,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1304,6 +1286,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,7 +1314,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1328,11 +1327,11 @@ dependencies = [
  "common",
  "glob-match",
  "graphql-parser",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "insta",
  "ndc-sdk",
  "prometheus",
- "reqwest 0.12.20",
+ "reqwest",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -1359,10 +1358,10 @@ dependencies = [
 
 [[package]]
 name = "ndc-models"
-version = "0.1.6"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.6#d1be19e9cdd86ac7b6ad003ff82b7e5b4e96b84f"
+version = "0.2.10"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.10#b8e165ce31d25abd84a6fcb41fc61190227654b8"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "ref-cast",
  "schemars 0.8.22",
  "serde",
@@ -1373,17 +1372,16 @@ dependencies = [
 
 [[package]]
 name = "ndc-sdk"
-version = "0.4.0"
-source = "git+https://github.com/hasura/ndc-sdk-rs?tag=v0.4.0#665509f7d3b47ce4f014fc23f817a3599ba13933"
+version = "0.8.1"
+source = "git+https://github.com/hasura/ndc-sdk-rs?rev=6ffe31a2acc652025405ce2aa35d82df10cb1d35#6ffe31a2acc652025405ce2aa35d82df10cb1d35"
 dependencies = [
  "async-trait",
  "axum",
  "axum-extra",
- "bytes",
  "clap",
- "http 0.2.12",
- "mime",
+ "http",
  "ndc-models",
+ "ndc-sdk-core",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
@@ -1391,16 +1389,35 @@ dependencies = [
  "opentelemetry-zipkin",
  "opentelemetry_sdk",
  "prometheus",
- "reqwest 0.11.27",
- "serde",
+ "reqwest",
+ "semver",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tower-http 0.4.4",
+ "tower-http",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "ndc-sdk-core"
+version = "0.8.1"
+source = "git+https://github.com/hasura/ndc-sdk-rs?rev=6ffe31a2acc652025405ce2aa35d82df10cb1d35#6ffe31a2acc652025405ce2aa35d82df10cb1d35"
+dependencies = [
+ "async-trait",
+ "axum",
+ "bytes",
+ "http",
+ "mime",
+ "ndc-models",
+ "prometheus",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1455,7 +1472,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1495,58 +1512,55 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.22.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
- "once_cell",
  "pin-project-lite",
- "thiserror 1.0.69",
- "urlencoding",
+ "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.11.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
 dependencies = [
  "async-trait",
  "bytes",
- "http 0.2.12",
+ "http",
  "opentelemetry",
- "reqwest 0.11.27",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.15.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
 dependencies = [
- "async-trait",
- "futures-core",
- "http 0.2.12",
+ "http",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.11.27",
- "thiserror 1.0.69",
+ "reqwest",
+ "thiserror 2.0.12",
  "tokio",
  "tonic",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.5.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1556,60 +1570,44 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+checksum = "1cefe0543875379e47eb5f1e68ff83f45cc41366a92dfd0d073d513bf68e9a05"
 
 [[package]]
 name = "opentelemetry-zipkin"
-version = "0.20.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6943c09b1b7c17b403ae842b00f23e6d5fc6f5ec06cccb3f39aca97094a899a"
+checksum = "8823568a9abd4003d1acc564bcfec8e3406a8c73203f8f50bdfc88b44d7ecfb6"
 dependencies = [
- "async-trait",
- "futures-core",
- "http 0.2.12",
+ "http",
  "once_cell",
  "opentelemetry",
  "opentelemetry-http",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "typed-builder",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.22.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
 dependencies = [
- "async-trait",
- "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
- "once_cell",
  "opentelemetry",
- "ordered-float",
  "percent-encoding",
- "rand 0.8.5",
- "thiserror 1.0.69",
+ "rand",
+ "serde_json",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "ordered-float"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1720,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -1730,14 +1728,14 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1745,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1758,9 +1756,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "quinn"
@@ -1774,8 +1786,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.28",
- "socket2",
+ "rustls",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -1791,10 +1803,10 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.28",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -1812,7 +1824,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -1834,33 +1846,12 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1870,16 +1861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1897,7 +1879,7 @@ version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -1966,75 +1948,44 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
- "base64 0.21.7",
+ "async-compression",
+ "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
- "ipnet",
+ "hyper-util",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.12.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.28",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.2",
- "tower 0.5.2",
- "tower-http 0.6.6",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2075,7 +2026,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2084,73 +2035,29 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
+ "security-framework 3.3.0",
 ]
 
 [[package]]
@@ -2161,27 +2068,6 @@ checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -2233,7 +2119,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -2271,23 +2157,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
- "core-foundation",
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2304,19 +2193,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2336,15 +2241,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2375,11 +2281,11 @@ version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "schemars 0.9.0",
  "serde",
  "serde_derive",
@@ -2462,6 +2368,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,12 +2425,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -2529,20 +2445,20 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
+ "bitflags",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2668,29 +2584,21 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2716,22 +2624,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.28",
+ "rustls",
  "tokio",
 ]
 
@@ -2761,51 +2658,28 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum",
- "base64 0.21.7",
+ "base64",
  "bytes",
  "flate2",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
  "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
  "rustls-native-certs",
- "rustls-pemfile 2.2.0",
- "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2819,28 +2693,12 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.11.4",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "slab",
+ "sync_wrapper",
  "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
-dependencies = [
- "bitflags 2.9.1",
- "bytes",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
- "mime",
- "pin-project-lite",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2852,16 +2710,23 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.1",
+ "async-compression",
+ "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
+ "http-body-util",
  "iri-string",
+ "mime",
  "pin-project-lite",
- "tower 0.5.2",
+ "tokio",
+ "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2922,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.23.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -2975,18 +2840,18 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-builder"
-version = "0.18.2"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77739c880e00693faef3d65ea3aad725f196da38b22fdc7ea6ded6e1ce4d3add"
+checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
 dependencies = [
  "typed-builder-macro",
 ]
 
 [[package]]
 name = "typed-builder-macro"
-version = "0.18.2"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
+checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3017,12 +2882,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3045,6 +2904,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -3253,6 +3118,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3268,15 +3144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3304,21 +3171,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3355,12 +3207,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3373,12 +3219,6 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3388,12 +3228,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3421,12 +3255,6 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3436,12 +3264,6 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3457,12 +3279,6 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3472,12 +3288,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3492,22 +3302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -3618,4 +3418,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,9 +346,8 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.8.1"
+version = "0.3.0"
 dependencies = [
- "async-trait",
  "glob-match",
  "graphql-parser",
  "graphql_client",
@@ -357,7 +356,6 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "tokio",
 ]
 
 [[package]]
@@ -1304,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-graphql"
-version = "0.8.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "common",
@@ -1316,7 +1314,6 @@ dependencies = [
  "prometheus",
  "reqwest",
  "schemars 0.8.22",
- "serde",
  "serde_json",
  "tokio",
  "tracing",
@@ -1324,11 +1321,10 @@ dependencies = [
 
 [[package]]
 name = "ndc-graphql-cli"
-version = "0.8.1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "common",
- "graphql-introspection-query",
  "graphql-parser",
  "graphql_client",
  "insta",
@@ -1356,7 +1352,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.8.1"
-source = "git+https://github.com/hasura/ndc-sdk-rs?rev=cc12fdaa9a452c6e61c69d802b824c0169fc0b53#cc12fdaa9a452c6e61c69d802b824c0169fc0b53"
+source = "git+https://github.com/hasura/ndc-sdk-rs?tag=v0.9.0-beta.1#cc12fdaa9a452c6e61c69d802b824c0169fc0b53"
 dependencies = [
  "async-trait",
  "axum",
@@ -1387,7 +1383,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk-core"
 version = "0.8.1"
-source = "git+https://github.com/hasura/ndc-sdk-rs?rev=cc12fdaa9a452c6e61c69d802b824c0169fc0b53#cc12fdaa9a452c6e61c69d802b824c0169fc0b53"
+source = "git+https://github.com/hasura/ndc-sdk-rs?tag=v0.9.0-beta.1#cc12fdaa9a452c6e61c69d802b824c0169fc0b53"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -73,35 +67,35 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "async-compression"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977eb15ea9efd848bb8a4a1a2500347ed7f0bf794edf0dc3ddcf439f43d36b23"
+checksum = "9611ec0b6acea03372540509035db2f7f1e9f04da5d27728436fa994033c00a0"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -118,7 +112,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -135,13 +129,13 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -169,13 +163,12 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
@@ -190,21 +183,20 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.9.6"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
 dependencies = [
  "axum",
  "axum-core",
  "bytes",
- "fastrand",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "mime",
- "multer",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "tower",
  "tower-layer",
@@ -234,9 +226,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bstr"
@@ -262,10 +254,11 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -273,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
@@ -285,22 +278,21 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -308,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -320,14 +312,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -354,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.2.3"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "glob-match",
@@ -427,18 +419,18 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -446,37 +438,37 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -487,14 +479,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -525,12 +517,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -538,6 +530,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "flate2"
@@ -572,9 +570,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -620,7 +618,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -675,7 +673,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -700,8 +698,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -789,9 +787,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -859,13 +857,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -873,6 +872,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -926,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64",
  "bytes",
@@ -942,7 +942,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1068,9 +1068,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1105,7 +1105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.0",
  "serde",
  "serde_core",
 ]
@@ -1159,9 +1159,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1184,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1200,15 +1200,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1228,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru-slab"
@@ -1240,24 +1240,24 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mime"
@@ -1286,23 +1286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "version_check",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-graphql"
-version = "0.2.3"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "common",
@@ -1341,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-graphql-cli"
-version = "0.2.3"
+version = "0.8.1"
 dependencies = [
  "clap",
  "common",
@@ -1373,7 +1356,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.8.1"
-source = "git+https://github.com/hasura/ndc-sdk-rs?rev=6ffe31a2acc652025405ce2aa35d82df10cb1d35#6ffe31a2acc652025405ce2aa35d82df10cb1d35"
+source = "git+https://github.com/hasura/ndc-sdk-rs?rev=cc12fdaa9a452c6e61c69d802b824c0169fc0b53#cc12fdaa9a452c6e61c69d802b824c0169fc0b53"
 dependencies = [
  "async-trait",
  "axum",
@@ -1404,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk-core"
 version = "0.8.1"
-source = "git+https://github.com/hasura/ndc-sdk-rs?rev=6ffe31a2acc652025405ce2aa35d82df10cb1d35#6ffe31a2acc652025405ce2aa35d82df10cb1d35"
+source = "git+https://github.com/hasura/ndc-sdk-rs?rev=cc12fdaa9a452c6e61c69d802b824c0169fc0b53#cc12fdaa9a452c6e61c69d802b824c0169fc0b53"
 dependencies = [
  "async-trait",
  "axum",
@@ -1422,12 +1405,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1489,7 +1471,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1520,7 +1502,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -1550,7 +1532,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tonic",
  "tracing",
@@ -1588,7 +1570,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "typed-builder",
 ]
 
@@ -1605,16 +1587,10 @@ dependencies = [
  "percent-encoding",
  "rand",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1641,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
@@ -1662,7 +1638,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1685,9 +1661,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
@@ -1709,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -1728,7 +1704,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1751,7 +1727,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1776,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1787,8 +1763,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
- "thiserror 2.0.12",
+ "socket2",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "web-time",
@@ -1796,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",
@@ -1809,7 +1785,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1817,16 +1793,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1846,9 +1822,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1875,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
@@ -1899,52 +1875,25 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
@@ -2010,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -2022,22 +1971,22 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "log",
  "once_cell",
@@ -2057,7 +2006,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.3.0",
+ "security-framework 3.5.0",
 ]
 
 [[package]]
@@ -2072,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2083,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -2104,11 +2053,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2139,6 +2088,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,7 +2108,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2171,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+checksum = "cc198e42d9b7510827939c9a15f5062a0c913f3371d765977e586d2fe6c16f4a"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.1",
@@ -2184,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2225,7 +2186,7 @@ checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2236,7 +2197,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2255,12 +2216,13 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
  "itoa",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2277,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e"
 dependencies = [
  "base64",
  "chrono",
@@ -2287,6 +2249,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.11.4",
  "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2296,14 +2259,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.13.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+checksum = "327ada00f7d64abaac1e55a6911e90cf665aa051b9a561c7006c157f4633135e"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2323,9 +2286,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -2338,9 +2301,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -2359,16 +2322,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -2376,12 +2329,6 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2414,9 +2361,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2440,7 +2387,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2466,15 +2413,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2488,11 +2435,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -2503,18 +2450,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2528,9 +2475,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
@@ -2543,15 +2490,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2569,9 +2516,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2596,7 +2543,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.59.0",
 ]
@@ -2609,7 +2556,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2624,9 +2571,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
 dependencies = [
  "rustls",
  "tokio",
@@ -2645,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2761,7 +2708,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2815,14 +2762,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -2855,14 +2802,14 @@ checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "untrusted"
@@ -2872,13 +2819,14 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2904,12 +2852,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2938,44 +2880,54 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2986,9 +2938,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2996,31 +2948,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3038,55 +2990,33 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.0",
+ "windows-result 0.4.0",
+ "windows-strings 0.5.0",
 ]
 
 [[package]]
@@ -3097,7 +3027,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3108,7 +3038,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3118,14 +3048,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-registry"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -3134,7 +3070,16 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -3143,7 +3088,16 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -3170,7 +3124,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -3191,10 +3154,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -3302,13 +3266,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
@@ -3336,28 +3297,28 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3377,7 +3338,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -3400,9 +3361,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3417,7 +3378,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/ndc-graphql", "crates/ndc-graphql-cli", "crates/common"]
 resolver = "2"
 
-package.version = "0.8.1"
+package.version = "0.3.0"
 package.edition = "2021"
 package.license = "Apache-2.0"
 
@@ -15,7 +15,8 @@ graphql-introspection-query = "0.2"
 graphql-parser = "0.4"
 indexmap = "2.11"
 ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.10" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs", rev = "cc12fdaa9a452c6e61c69d802b824c0169fc0b53", package = "ndc-sdk", features = [
+# 
+ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs", tag = "v0.9.0-beta.1", package = "ndc-sdk", features = [
     "rustls",
 ], default-features = false }
 prometheus = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,45 @@
 members = ["crates/ndc-graphql", "crates/ndc-graphql-cli", "crates/common"]
 resolver = "2"
 
-package.version = "0.2.3"
+package.version = "0.8.1"
 package.edition = "2021"
+package.license = "Apache-2.0"
+
+[workspace.dependencies]
+async-trait = "0.1"
+clap = { version = "4", features = ["derive", "env"] }
+glob-match = "0.2"
+graphql_client = "0.14"
+graphql-introspection-query = "0.2"
+graphql-parser = "0.4"
+indexmap = "2.11"
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.10" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs", rev = "cc12fdaa9a452c6e61c69d802b824c0169fc0b53", package = "ndc-sdk", features = [
+    "rustls",
+], default-features = false }
+prometheus = "0.14"
+reqwest = { version = "0.12", features = [
+    "json",
+    "rustls-tls",
+], default-features = false }
+schemars = "0.8.22"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
+tracing = "0.1"
 
 # insta performs better in release mode
 [profile.dev.package]
 insta.opt-level = 3
 similar.opt-level = 3
+
+[workspace.lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+# disable certain pedantic warnings
+doc_markdown = { level = "allow" }
+missing_errors_doc = { level = "allow" }
+missing_panics_doc = { level = "allow" }
+module_name_repetitions = { level = "allow" }
+must_use_candidate = { level = "allow" }
+wildcard_imports = { level = "allow" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/LukeMathWalker/cargo-chef
-FROM rust:1.82 AS chef
+FROM rust:1.89 AS chef
 RUN cargo install cargo-chef
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -40,18 +40,19 @@ from headers to the argument by the engine via [the new `ArgumentPresets` featur
 
 Below, you'll find a matrix of all supported features for the GraphQL connector:
 
-| Feature                | Supported | Notes |
-| ---------------------- | --------- | ----- |
-| Queries                | ✅        | All features that v3 engine currently supports
-| Mutations              | ✅        |
-| Header Passthrough     | ✅        | Entire headers can be forwarded
-| Subscriptions          | ❌        |
-| Unions                 | ❌        | Can be brought in via scalar types
-| Interfaces             | ❌        |
-| Relay API              | ❌        |
-| Directives             | ❌        | @cached, Apollo directives
+| Feature                 | Supported | Notes                                                        |
+| ----------------------- | --------- | ------------------------------------------------------------ |
+| Queries                 | ✅         | All features that v3 engine currently supports               |
+| Mutations               | ✅         |                                                              |
+| Header Passthrough      | ✅         | Entire headers can be forwarded                              |
+| Request-level Arguments | ✅         | Support dynamic headers from the from Pre-NDC Request Plugin |
+| Subscriptions           | ❌         |                                                              |
+| Unions                  | ❌         | Can be brought in via scalar types                           |
+| Interfaces              | ❌         |                                                              |
+| Relay API               | ❌         |                                                              |
+| Directives              | ❌         | @cached, Apollo directives                                   |
 
-#### Other Considerations and limitations
+## Other Considerations and limitations
 
 * Error formatting
   - The format of errors from the connector does not currently match V2 error formatting
@@ -62,9 +63,30 @@ Below, you'll find a matrix of all supported features for the GraphQL connector:
 * Response headers only allow at most one header per name
   - For example you may only use one `Set-Cookie` response header
 
-
 ## Using the GraphQL Connector
 
 This connector should be used with Hasura DDN.
 Please see the [relevant documentation](https://hasura.info/graphql-getting-started).
 
+## Advanced Features
+
+### Forward Headers from Pre-NDC Request Plugin
+ 
+You can use a [Pre-NDC Request Plugin](https://hasura.io/docs/3.0/plugins/introduction#pre-ndc-request-plugin) to modify the request, and add dynamic headers in runtime via `request_arguments.headers` field, which is a string map. Those headers will be merged into the HTTP request headers before being sent to external services.
+
+> See the full example at [Pre-NDC Request Plugin Request](https://hasura.io/docs/3.0/plugins/introduction#example-configuration)
+ 
+```json
+{
+  // ...
+  "ndcRequest": {
+    // ...
+    "request_arguments": {
+        "headers": {
+            "Authorization": "Bearer <token>",
+            "X-Custom-Header": "foo"
+        }
+    }
+  }
+}
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported Versions
+
+| Version  | Supported          |
+| -------- | ------------------ |
+| >= 0.1.0 | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+We’re extremely grateful for security researchers and users who report vulnerabilities to the community.
+All reports are thoroughly investigated by a set of community volunteers.
+
+### When Should I Report a Vulnerability?
+
+- You think you have discovered a potential security vulnerability in the GraphQL connector or related components.
+- You are unsure how a vulnerability affects the connector.
+- You think you discovered a vulnerability in another project that connector depends on (e.g. Docker, etc).
+- You want to report any other security risk that could potentially harm connector users.
+
+### When Should I NOT Report a Vulnerability?
+
+- You need help applying security-related updates.
+- Your issue is not security-related.
+
+### Security Vulnerability Response
+
+Each report is acknowledged and analyzed by the project's maintainers. New pull requests are welcome too.

--- a/ci/templates/connector-metadata.yaml
+++ b/ci/templates/connector-metadata.yaml
@@ -46,4 +46,4 @@ dockerComposeWatch:
   - path: ./
     target: /etc/connector
     action: sync+restart
-documentationPage: https://hasura.info/graphql-getting-started
+documentationPage: https://hasura.io/docs/3.0/reference/connectors/graphql

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -4,16 +4,16 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-async-trait = "0.1.78"
-glob-match = "0.2.1"
-graphql_client = "0.14.0"
-graphql-parser = "0.4.0"
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.6" }
-reqwest = { version = "0.12.7", features = [
+async-trait = "0.1"
+glob-match = "0.2"
+graphql_client = "0.14"
+graphql-parser = "0.4"
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.10" }
+reqwest = { version = "0.12", features = [
     "json",
     "rustls-tls",
 ], default-features = false }
-schemars = "0.8.16"
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.114"
-tokio = "1.36.0"
+schemars = "0.8.22"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = "1"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -4,16 +4,13 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-async-trait = "0.1"
-glob-match = "0.2"
-graphql_client = "0.14"
-graphql-parser = "0.4"
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.10" }
-reqwest = { version = "0.12", features = [
-    "json",
-    "rustls-tls",
-], default-features = false }
-schemars = "0.8.22"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tokio = "1"
+async-trait = { workspace = true }
+glob-match = { workspace = true }
+graphql_client = { workspace = true }
+graphql-parser = { workspace = true }
+ndc-models = { workspace = true }
+reqwest = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-async-trait = { workspace = true }
 glob-match = { workspace = true }
 graphql_client = { workspace = true }
 graphql-parser = { workspace = true }
@@ -13,4 +12,3 @@ reqwest = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }

--- a/crates/common/src/capabilities.rs
+++ b/crates/common/src/capabilities.rs
@@ -10,9 +10,13 @@ pub fn capabilities() -> models::Capabilities {
                 aggregates: None,
                 filter_by: None,
                 order_by: None,
+                nested_collections: None,
             },
             exists: models::ExistsCapabilities {
                 nested_collections: None,
+                named_scopes: None,
+                nested_scalar_collections: None,
+                unrelated: None,
             },
         },
         mutation: models::MutationCapabilities {
@@ -20,6 +24,8 @@ pub fn capabilities() -> models::Capabilities {
             explain: Some(models::LeafCapability {}),
         },
         relationships: None,
+        relational_mutation: None,
+        relational_query: None,
     }
 }
 

--- a/crates/common/src/schema_response.rs
+++ b/crates/common/src/schema_response.rs
@@ -5,7 +5,9 @@ use crate::config::{
     },
     RequestConfig, ResponseConfig,
 };
-use ndc_models::{self as models, ArgumentName, FieldName, SchemaResponse};
+use ndc_models::{
+    self as models, ArgumentName, FieldName, SchemaResponse, TypeName, TypeRepresentation,
+};
 use std::{collections::BTreeMap, iter};
 
 pub fn schema_response(
@@ -24,9 +26,10 @@ pub fn schema_response(
             TypeDef::Scalar { description: _ } => Some((
                 name.to_owned().into(),
                 models::ScalarType {
-                    representation: None,
+                    representation: type_name_to_representation(name),
                     aggregate_functions: BTreeMap::new(),
                     comparison_operators: BTreeMap::new(),
+                    extraction_functions: BTreeMap::new(),
                 },
             )),
             TypeDef::Enum {
@@ -35,11 +38,12 @@ pub fn schema_response(
             } => Some((
                 name.to_owned().into(),
                 models::ScalarType {
-                    representation: Some(models::TypeRepresentation::Enum {
+                    representation: models::TypeRepresentation::Enum {
                         one_of: values.iter().map(|value| value.name.to_owned()).collect(),
-                    }),
+                    },
                     aggregate_functions: BTreeMap::new(),
                     comparison_operators: BTreeMap::new(),
+                    extraction_functions: BTreeMap::new(),
                 },
             )),
         })
@@ -49,9 +53,10 @@ pub fn schema_response(
         scalar_types.insert(
             request.headers_type_name.to_owned(),
             models::ScalarType {
-                representation: Some(models::TypeRepresentation::JSON),
+                representation: models::TypeRepresentation::JSON,
                 aggregate_functions: BTreeMap::new(),
                 comparison_operators: BTreeMap::new(),
+                extraction_functions: BTreeMap::new(),
             },
         );
     }
@@ -69,6 +74,7 @@ pub fn schema_response(
                 models::ObjectType {
                     description: description.to_owned(),
                     fields: fields.iter().map(map_object_field).collect(),
+                    foreign_keys: BTreeMap::new(),
                 },
             )),
             TypeDef::InputObject {
@@ -79,6 +85,7 @@ pub fn schema_response(
                 models::ObjectType {
                     description: description.to_owned(),
                     fields: fields.iter().map(map_input_object_field).collect(),
+                    foreign_keys: BTreeMap::new(),
                 },
             )),
         })
@@ -110,6 +117,7 @@ pub fn schema_response(
                         },
                     ),
                 ]),
+                foreign_keys: BTreeMap::new(),
             }
         };
 
@@ -205,6 +213,8 @@ pub fn schema_response(
         collections: vec![],
         functions,
         procedures,
+        capabilities: None,
+        request_arguments: None,
     }
 }
 
@@ -268,5 +278,24 @@ fn typeref_to_ndc_type(typeref: &TypeRef) -> models::Type {
             // ignore (illegal) double non-null assertions. This shouln't happen anyways
             TypeRef::NonNull(_) => typeref_to_ndc_type(inner),
         },
+    }
+}
+
+// Guess the type representation by common GraphQL scalar names such as String, Int, Float, Boolean, etc...
+// https://spec.graphql.org/draft/#sec-Scalars.Built-in-Scalars
+fn type_name_to_representation(name: &TypeName) -> TypeRepresentation {
+    match name.to_string().to_lowercase().as_str() {
+        "bool" | "boolean" => TypeRepresentation::Boolean,
+        "int8" | "tinyint" => TypeRepresentation::Int8,
+        "int16" | "smallint" => TypeRepresentation::Int16,
+        "int" | "int32" | "serial" => TypeRepresentation::Int32,
+        "int64" => TypeRepresentation::Int64,
+        "bigint" | "bigserial" => TypeRepresentation::BigInteger,
+        "float8" | "float16" | "float32" => TypeRepresentation::Float32,
+        "float" | "float64" => TypeRepresentation::Float64,
+        "date" => TypeRepresentation::Date,
+        "timestamptz" | "datetime" => TypeRepresentation::TimestampTZ,
+        "id" | "string" | "uuid" | "text" | "citext" | "varchar" => TypeRepresentation::String,
+        _ => TypeRepresentation::JSON,
     }
 }

--- a/crates/ndc-graphql-cli/Cargo.toml
+++ b/crates/ndc-graphql-cli/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 common = { path = "../common" }
 clap = { workspace = true }
 graphql_client = { workspace = true }
-graphql-introspection-query = { workspace = true }
 graphql-parser = { workspace = true }
 ndc-models = { workspace = true }
 schemars = { workspace = true }

--- a/crates/ndc-graphql-cli/Cargo.toml
+++ b/crates/ndc-graphql-cli/Cargo.toml
@@ -4,16 +4,16 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-clap = { version = "4", features = ["derive", "env"] }
 common = { path = "../common" }
-graphql_client = "0.14"
-graphql-introspection-query = "0.2"
-graphql-parser = "0.4"
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.10" }
-schemars = "0.8.22"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
+clap = { workspace = true }
+graphql_client = { workspace = true }
+graphql-introspection-query = { workspace = true }
+graphql-parser = { workspace = true }
+ndc-models = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 insta = { version = "1.43", features = ["yaml"] }

--- a/crates/ndc-graphql-cli/Cargo.toml
+++ b/crates/ndc-graphql-cli/Cargo.toml
@@ -4,16 +4,16 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-clap = { version = "4.5.3", features = ["derive", "env"] }
+clap = { version = "4", features = ["derive", "env"] }
 common = { path = "../common" }
-graphql_client = "0.14.0"
-graphql-introspection-query = "0.2.0"
-graphql-parser = "0.4.0"
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.6" }
-schemars = "0.8.16"
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.114"
-tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread", "fs"] }
+graphql_client = "0.14"
+graphql-introspection-query = "0.2"
+graphql-parser = "0.4"
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.10" }
+schemars = "0.8.22"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
 
 [dev-dependencies]
-insta = { version = "1.40.0", features = ["yaml"] }
+insta = { version = "1.43", features = ["yaml"] }

--- a/crates/ndc-graphql/Cargo.toml
+++ b/crates/ndc-graphql/Cargo.toml
@@ -4,24 +4,24 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-async-trait = "0.1.78"
+async-trait = "0.1"
 common = { path = "../common" }
-glob-match = "0.2.1"
-graphql-parser = "0.4.0"
-indexmap = "2.1.0"
-ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs", tag = "v0.4.0", package = "ndc-sdk", features = [
+glob-match = "0.2"
+graphql-parser = "0.4"
+indexmap = "2.11"
+ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs", rev = "6ffe31a2acc652025405ce2aa35d82df10cb1d35", package = "ndc-sdk", features = [
   "rustls",
 ], default-features = false }
-prometheus = "0.13.3"
-reqwest = { version = "0.12.3", features = [
+prometheus = "0.14"
+reqwest = { version = "0.12", features = [
   "json",
   "rustls-tls",
 ], default-features = false }
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.114"
-tokio = "1.36.0"
-tracing = "0.1.40"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = "1"
+tracing = "0.1"
 
 [dev-dependencies]
-insta = { version = "1.40.0", features = ["yaml", "glob", "json"] }
-schemars = "0.8.16"
+insta = { version = "1.43", features = ["yaml", "glob", "json"] }
+schemars = "0.8.22"

--- a/crates/ndc-graphql/Cargo.toml
+++ b/crates/ndc-graphql/Cargo.toml
@@ -3,24 +3,22 @@ name = "ndc-graphql"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
-async-trait = "0.1"
 common = { path = "../common" }
-glob-match = "0.2"
-graphql-parser = "0.4"
-indexmap = "2.11"
-ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs", rev = "6ffe31a2acc652025405ce2aa35d82df10cb1d35", package = "ndc-sdk", features = [
-  "rustls",
-], default-features = false }
-prometheus = "0.14"
-reqwest = { version = "0.12", features = [
-  "json",
-  "rustls-tls",
-], default-features = false }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tokio = "1"
-tracing = "0.1"
+async-trait = { workspace = true }
+glob-match = { workspace = true }
+graphql-parser = { workspace = true }
+indexmap = { workspace = true }
+ndc-sdk = { workspace = true }
+prometheus = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 insta = { version = "1.43", features = ["yaml", "glob", "json"] }

--- a/crates/ndc-graphql/Cargo.toml
+++ b/crates/ndc-graphql/Cargo.toml
@@ -15,7 +15,6 @@ indexmap = { workspace = true }
 ndc-sdk = { workspace = true }
 prometheus = { workspace = true }
 reqwest = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/ndc-graphql/src/connector.rs
+++ b/crates/ndc-graphql/src/connector.rs
@@ -28,6 +28,14 @@ impl Connector for GraphQLConnector {
         Ok(())
     }
 
+    fn connector_name() -> &'static str {
+        "ndc_graphql"
+    }
+
+    fn connector_version() -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+
     async fn get_capabilities() -> models::Capabilities {
         capabilities()
     }

--- a/crates/ndc-graphql/src/connector/mutation.rs
+++ b/crates/ndc-graphql/src/connector/mutation.rs
@@ -83,10 +83,9 @@ pub async fn handle_mutation(
                 .map(|(index, operation)| match operation {
                     models::MutationOperation::Procedure { .. } => Ok({
                         let alias = format!("procedure_{index}");
-                        let result = data
-                            .get_mut(&alias)
-                            .map(|val| mem::replace(val, serde_json::Value::Null))
-                            .unwrap_or(serde_json::Value::Null);
+                        let result = data.get_mut(&alias).map_or(serde_json::Value::Null, |val| {
+                            mem::replace(val, serde_json::Value::Null)
+                        });
                         let result = if forward_response_headers {
                             serde_json::to_value(BTreeMap::from_iter(vec![
                                 (

--- a/crates/ndc-graphql/src/connector/query.rs
+++ b/crates/ndc-graphql/src/connector/query.rs
@@ -100,6 +100,7 @@ pub async fn handle_query(
             };
 
             Ok(models::QueryResponse(vec![models::RowSet {
+                groups: None,
                 aggregates: None,
                 rows: Some(vec![row]),
             }]))

--- a/crates/ndc-graphql/src/connector/setup.rs
+++ b/crates/ndc-graphql/src/connector/setup.rs
@@ -38,13 +38,6 @@ impl ConnectorSetup for GraphQLConnectorSetup {
         Ok(self.read_configuration(configuration_dir).await?)
     }
 
-    // async fn parse_configuration(
-    //     &self,
-    //     configuration_dir: impl AsRef<Path> + Send,
-    // ) -> connector::Result<<Self::Connector as Connector>::Configuration> {
-    //     Ok(self.read_configuration(configuration_dir).await?)
-    // }
-
     async fn try_init_state(
         &self,
         configuration: &<Self::Connector as Connector>::Configuration,

--- a/crates/ndc-graphql/src/connector/setup.rs
+++ b/crates/ndc-graphql/src/connector/setup.rs
@@ -26,12 +26,24 @@ pub struct GraphQLConnectorSetup {
 impl ConnectorSetup for GraphQLConnectorSetup {
     type Connector = GraphQLConnector;
 
+    /// Validate the configuration provided by the user, returning a configuration error or a
+    /// validated [`Configuration`].
+    ///
+    /// The [`ParseError`] type is provided as a convenience to connector authors, to be used on
+    /// error.
     async fn parse_configuration(
         &self,
-        configuration_dir: impl AsRef<Path> + Send,
+        configuration_dir: &Path,
     ) -> connector::Result<<Self::Connector as Connector>::Configuration> {
         Ok(self.read_configuration(configuration_dir).await?)
     }
+
+    // async fn parse_configuration(
+    //     &self,
+    //     configuration_dir: impl AsRef<Path> + Send,
+    // ) -> connector::Result<<Self::Connector as Connector>::Configuration> {
+    //     Ok(self.read_configuration(configuration_dir).await?)
+    // }
 
     async fn try_init_state(
         &self,

--- a/crates/ndc-graphql/src/query_builder.rs
+++ b/crates/ndc-graphql/src/query_builder.rs
@@ -98,6 +98,11 @@ pub fn build_mutation_document(
         }
     }
 
+    let mut request_level_headers =
+        extract_headers_from_request_arguments(request.request_arguments.as_ref())?;
+
+    request_headers.append(&mut request_level_headers);
+
     let selection_set = SelectionSet {
         span: (pos(), pos()),
         items,
@@ -123,6 +128,7 @@ pub fn build_mutation_document(
         headers: request_headers,
     })
 }
+
 pub fn build_query_document(
     request: &models::QueryRequest,
     configuration: &ServerConfig,
@@ -170,10 +176,10 @@ pub fn build_query_document(
         .query_fields
         .get(&request.collection)
         .ok_or_else(|| QueryBuilderError::QueryFieldNotFound {
-            field: request.collection.to_owned(),
+            field: request.collection.clone(),
         })?;
 
-    let (headers, items, variable_values, variable_definitions) =
+    let (mut headers, items, variable_values, variable_definitions) =
         if let Some(variables) = &request.variables {
             let mut variable_values = BTreeMap::new();
             let mut variable_definitions = vec![];
@@ -213,7 +219,7 @@ pub fn build_query_document(
                 items.push(item);
 
                 variable_values.append(&mut values);
-                variable_definitions.append(&mut definitions)
+                variable_definitions.append(&mut definitions);
             }
 
             (all_headers, items, variable_values, variable_definitions)
@@ -252,6 +258,11 @@ pub fn build_query_document(
 
             (headers, vec![item], variable_values, variable_definitions)
         };
+
+    let mut request_level_headers =
+        extract_headers_from_request_arguments(request.request_arguments.as_ref())?;
+
+    headers.append(&mut request_level_headers);
 
     let selection_set = SelectionSet {
         span: (pos(), pos()),
@@ -307,9 +318,7 @@ where
                 | serde_json::Value::Number(_)
                 | serde_json::Value::String(_)
                 | serde_json::Value::Array(_) => {
-                    return Err(QueryBuilderError::MisshapenHeadersArgument(
-                        value.to_owned(),
-                    ))
+                    return Err(QueryBuilderError::MisshapenHeadersArgument(value.clone()))
                 }
                 serde_json::Value::Object(object) => {
                     for (name, value) in object {
@@ -320,7 +329,7 @@ where
                             | serde_json::Value::Array(_)
                             | serde_json::Value::Object(_) => {
                                 return Err(QueryBuilderError::MisshapenHeadersArgument(
-                                    value.to_owned(),
+                                    value.clone(),
                                 ))
                             }
                             serde_json::Value::String(header) => {
@@ -342,6 +351,7 @@ where
 
     Ok((headers, request_arguments))
 }
+
 #[allow(clippy::too_many_arguments)]
 fn selection_set_field<'a>(
     alias: &str,
@@ -381,12 +391,12 @@ fn selection_set_field<'a>(
                             description: _,
                         }) => fields.get(field_name).ok_or_else(|| {
                             QueryBuilderError::ObjectFieldNotFound {
-                                object: field_definition.r#type.name().to_owned(),
-                                field: field_name.to_owned(),
+                                object: field_definition.r#type.name(),
+                                field: field_name.clone(),
                             }
                         }),
                         Some(_) | None => Err(QueryBuilderError::ObjectTypeNotFound(
-                            field_definition.r#type.name().to_owned(),
+                            field_definition.r#type.name(),
                         )),
                     }?;
 
@@ -426,7 +436,7 @@ fn selection_set_field<'a>(
         alias: if alias == field_name.inner() {
             None
         } else {
-            Some(alias.to_owned())
+            Some(alias.to_string())
         },
         name: field_name.to_string(),
         arguments,
@@ -434,6 +444,7 @@ fn selection_set_field<'a>(
         selection_set,
     }))
 }
+
 fn field_arguments<'a, A, M>(
     arguments: &BTreeMap<ArgumentName, A>,
     map_argument: M,
@@ -456,9 +467,9 @@ where
                 .arguments
                 .get(name)
                 .ok_or(QueryBuilderError::ArgumentNotFound {
-                    object: object_name.to_owned(),
-                    field: field_name.to_owned(),
-                    argument: name.to_owned(),
+                    object: object_name.clone(),
+                    field: field_name.clone(),
+                    argument: name.clone(),
                 })?
                 .r#type;
 
@@ -478,11 +489,12 @@ fn map_query_arg(
     match argument {
         Argument::Variable { name } => variables
             .get(name)
-            .map(|v| v.to_owned())
-            .ok_or_else(|| QueryBuilderError::MissingVariable(name.to_owned())),
+            .map(std::borrow::ToOwned::to_owned)
+            .ok_or_else(|| QueryBuilderError::MissingVariable(name.clone())),
         Argument::Literal { value } => Ok(value.to_owned()),
     }
 }
+
 fn map_arg(
     argument: &serde_json::Value,
     _variables: &BTreeMap<VariableName, serde_json::Value>,
@@ -495,5 +507,17 @@ fn underlying_fields(nested_field: &NestedField) -> Option<&IndexMap<FieldName, 
         NestedField::Object(obj) => Some(&obj.fields),
         NestedField::Array(arr) => underlying_fields(&arr.fields),
         NestedField::Collection(_) => None,
+    }
+}
+
+/// extract headers from the request_arguments object which is a string map.
+fn extract_headers_from_request_arguments(
+    request_arguments: Option<&BTreeMap<ArgumentName, serde_json::Value>>,
+) -> Result<BTreeMap<String, String>, QueryBuilderError> {
+    match request_arguments.and_then(|args| args.get("headers")) {
+        None => Ok(BTreeMap::new()),
+        Some(value) => serde_json::from_value::<Option<BTreeMap<String, String>>>(value.clone())
+            .map(Option::unwrap_or_default)
+            .map_err(|err| QueryBuilderError::Unexpected(err.to_string())),
     }
 }

--- a/crates/ndc-graphql/src/query_builder.rs
+++ b/crates/ndc-graphql/src/query_builder.rs
@@ -353,7 +353,7 @@ fn selection_set_field<'a>(
     configuration: &ServerConfig,
     variables: &BTreeMap<VariableName, serde_json::Value>,
 ) -> Result<Selection<'a, String>, QueryBuilderError> {
-    let selection_set = match fields.as_ref().map(underlying_fields) {
+    let selection_set = match fields.as_ref().and_then(underlying_fields) {
         Some(fields) => {
             let items = fields
                 .iter()
@@ -490,9 +490,10 @@ fn map_arg(
     Ok(argument.to_owned())
 }
 
-fn underlying_fields(nested_field: &NestedField) -> &IndexMap<FieldName, models::Field> {
+fn underlying_fields(nested_field: &NestedField) -> Option<&IndexMap<FieldName, models::Field>> {
     match nested_field {
-        NestedField::Object(obj) => &obj.fields,
+        NestedField::Object(obj) => Some(&obj.fields),
         NestedField::Array(arr) => underlying_fields(&arr.fields),
+        NestedField::Collection(_) => None,
     }
 }

--- a/crates/ndc-graphql/src/query_builder/error.rs
+++ b/crates/ndc-graphql/src/query_builder/error.rs
@@ -99,7 +99,7 @@ impl Display for QueryBuilderError {
                 write!(f, "Field {field} not found in Mutation type")
             }
             QueryBuilderError::MisshapenHeadersArgument(headers) => {
-                write!(f, "Misshapen headers argument: {}", headers)
+                write!(f, "Misshapen headers argument: {headers}")
             }
             QueryBuilderError::MissingVariable(name) => write!(f, "Missing variable {name}"),
         }

--- a/crates/ndc-graphql/tests/config-1/mutations/03_request_level_arguments.request.json
+++ b/crates/ndc-graphql/tests/config-1/mutations/03_request_level_arguments.request.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "_mutation_request.schema.json",
+    "operations": [
+        {
+            "type": "procedure",
+            "name": "update_Album_by_pk",
+            "arguments": {
+                "_set": {
+                    "ArtistId": 1
+                },
+                "pk_columns": {
+                    "AlbumId": 1
+                }
+            },
+            "fields": {
+                "type": "object",
+                "fields": {
+                    "AlbumId": {
+                        "type": "column",
+                        "column": "AlbumId",
+                        "fields": null
+                    },
+                    "Title": {
+                        "type": "column",
+                        "column": "Title",
+                        "fields": null
+                    }
+                }
+            }
+        }
+    ],
+    "collection_relationships": {},
+    "request_arguments": {
+        "headers": {
+            "Authorization": "unauthorized",
+            "X-User-ID": "1"
+        }
+    }
+}

--- a/crates/ndc-graphql/tests/config-1/queries/05_request_level_arguments.request.json
+++ b/crates/ndc-graphql/tests/config-1/queries/05_request_level_arguments.request.json
@@ -1,0 +1,103 @@
+{
+    "$schema": "_query_request.schema.json",
+    "collection": "Album",
+    "query": {
+        "fields": {
+            "__value": {
+                "type": "column",
+                "column": "__value",
+                "fields": {
+                    "type": "array",
+                    "fields": {
+                        "type": "object",
+                        "fields": {
+                            "AlbumId": {
+                                "type": "column",
+                                "column": "AlbumId",
+                                "fields": null
+                            },
+                            "Title": {
+                                "type": "column",
+                                "column": "Title",
+                                "fields": null
+                            },
+                            "Artist": {
+                                "type": "column",
+                                "column": "Artist",
+                                "fields": {
+                                    "type": "object",
+                                    "fields": {
+                                        "ArtistId": {
+                                            "type": "column",
+                                            "column": "ArtistId",
+                                            "fields": null
+                                        },
+                                        "Name": {
+                                            "type": "column",
+                                            "column": "Name",
+                                            "fields": null
+                                        }
+                                    }
+                                }
+                            },
+                            "Tracks": {
+                                "type": "column",
+                                "column": "Tracks",
+                                "fields": {
+                                    "type": "array",
+                                    "fields": {
+                                        "type": "object",
+                                        "fields": {
+                                            "TrackId": {
+                                                "type": "column",
+                                                "column": "TrackId",
+                                                "fields": null
+                                            },
+                                            "Name": {
+                                                "type": "column",
+                                                "column": "Name",
+                                                "fields": null
+                                            },
+                                            "UnitPrice": {
+                                                "type": "column",
+                                                "column": "UnitPrice",
+                                                "fields": null
+                                            },
+                                            "MediaType": {
+                                                "type": "column",
+                                                "column": "MediaType",
+                                                "fields": {
+                                                    "type": "object",
+                                                    "fields": {
+                                                        "Name": {
+                                                            "type": "column",
+                                                            "column": "Name",
+                                                            "fields": null
+                                                        },
+                                                        "MediaTypeId": {
+                                                            "type": "column",
+                                                            "column": "MediaTypeId",
+                                                            "fields": null
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "arguments": {},
+    "collection_relationships": {},
+    "request_arguments": {
+        "headers": {
+            "Authorization": "Bearer unauthorized",
+            "X-Test-Header": "test_value"
+        }
+    }
+}

--- a/crates/ndc-graphql/tests/query_builder.rs
+++ b/crates/ndc-graphql/tests/query_builder.rs
@@ -41,8 +41,8 @@ async fn read_configuration(config: &str) -> ServerConfig {
         .join(config)
         .join("configuration");
     let env = HashMap::from_iter(vec![
-        ("GRAPHQL_ENDPOINT".to_owned(), "".to_owned()),
-        ("GRAPHQL_ENDPOINT_SECRET".to_owned(), "".to_owned()),
+        ("GRAPHQL_ENDPOINT".to_owned(), String::new()),
+        ("GRAPHQL_ENDPOINT_SECRET".to_owned(), String::new()),
     ]);
     GraphQLConnectorSetup::new(env)
         .read_configuration(configuration_dir)
@@ -108,7 +108,7 @@ async fn test_generated_schema() {
 
 #[test]
 fn test_capabilities() {
-    assert_yaml_snapshot!("Capabilities", capabilities_response())
+    assert_yaml_snapshot!("Capabilities", capabilities_response());
 }
 
 #[test]
@@ -117,5 +117,5 @@ fn configuration_schema() {
         "Configuration JSON Schema",
         serde_json::to_string_pretty(&schema_for!(ServerConfigFile))
             .expect("Should serialize schema to json")
-    )
+    );
 }

--- a/crates/ndc-graphql/tests/snapshots/query_builder__Capabilities.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__Capabilities.snap
@@ -2,7 +2,7 @@
 source: crates/ndc-graphql/tests/query_builder.rs
 expression: capabilities_response()
 ---
-version: 0.1.6
+version: 0.2.10
 capabilities:
   query:
     variables: {}
@@ -11,3 +11,4 @@ capabilities:
     exists: {}
   mutation:
     explain: {}
+

--- a/crates/ndc-graphql/tests/snapshots/query_builder__Headers@03_request_level_arguments.request.json.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__Headers@03_request_level_arguments.request.json.snap
@@ -1,0 +1,8 @@
+---
+source: crates/ndc-graphql/tests/query_builder.rs
+assertion_line: 91
+expression: operation.headers
+input_file: crates/ndc-graphql/tests/config-1/mutations/03_request_level_arguments.request.json
+---
+Authorization: unauthorized
+X-User-ID: "1"

--- a/crates/ndc-graphql/tests/snapshots/query_builder__Headers@05_request_level_arguments.request.json.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__Headers@05_request_level_arguments.request.json.snap
@@ -1,0 +1,8 @@
+---
+source: crates/ndc-graphql/tests/query_builder.rs
+assertion_line: 72
+expression: operation.headers
+input_file: crates/ndc-graphql/tests/config-1/queries/05_request_level_arguments.request.json
+---
+Authorization: Bearer unauthorized
+X-Test-Header: test_value

--- a/crates/ndc-graphql/tests/snapshots/query_builder__Query String@03_request_level_arguments.request.json.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__Query String@03_request_level_arguments.request.json.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ndc-graphql/tests/query_builder.rs
+assertion_line: 89
+expression: operation.query
+input_file: crates/ndc-graphql/tests/config-1/mutations/03_request_level_arguments.request.json
+---
+mutation($arg_1__set: Album_set_input, $arg_2_pk_columns: Album_pk_columns_input!) {
+  procedure_0: update_Album_by_pk(_set: $arg_1__set, pk_columns: $arg_2_pk_columns) {
+    AlbumId
+    Title
+  }
+}

--- a/crates/ndc-graphql/tests/snapshots/query_builder__Query String@05_request_level_arguments.request.json.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__Query String@05_request_level_arguments.request.json.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ndc-graphql/tests/query_builder.rs
+assertion_line: 70
+expression: operation.query
+input_file: crates/ndc-graphql/tests/config-1/queries/05_request_level_arguments.request.json
+---
+query {
+  __value: Album {
+    AlbumId
+    Title
+    Artist {
+      ArtistId
+      Name
+    }
+    Tracks {
+      TrackId
+      Name
+      UnitPrice
+      MediaType {
+        Name
+        MediaTypeId
+      }
+    }
+  }
+}

--- a/crates/ndc-graphql/tests/snapshots/query_builder__Variables@03_request_level_arguments.request.json.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__Variables@03_request_level_arguments.request.json.snap
@@ -1,0 +1,14 @@
+---
+source: crates/ndc-graphql/tests/query_builder.rs
+assertion_line: 90
+expression: operation.variables
+input_file: crates/ndc-graphql/tests/config-1/mutations/03_request_level_arguments.request.json
+---
+{
+  "arg_1__set": {
+    "ArtistId": 1
+  },
+  "arg_2_pk_columns": {
+    "AlbumId": 1
+  }
+}

--- a/crates/ndc-graphql/tests/snapshots/query_builder__Variables@05_request_level_arguments.request.json.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__Variables@05_request_level_arguments.request.json.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ndc-graphql/tests/query_builder.rs
+assertion_line: 71
+expression: operation.variables
+input_file: crates/ndc-graphql/tests/config-1/queries/05_request_level_arguments.request.json
+---
+{}

--- a/crates/ndc-graphql/tests/snapshots/query_builder__config-1 NDC Schema.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__config-1 NDC Schema.snap
@@ -388,6 +388,12 @@ scalar_types:
     aggregate_functions: {}
     comparison_operators: {}
     extraction_functions: {}
+  _HeaderMap:
+    representation:
+      type: json
+    aggregate_functions: {}
+    comparison_operators: {}
+    extraction_functions: {}
   cursor_ordering:
     representation:
       type: enum
@@ -16660,4 +16666,21 @@ procedures:
             type: named
             name: Track_mutation_response
 capabilities: ~
-request_arguments: ~
+request_arguments:
+  query_arguments:
+    headers:
+      description: Headers to be merged into original request headers of graphql requests
+      type:
+        type: nullable
+        underlying_type:
+          type: named
+          name: _HeaderMap
+  mutation_arguments:
+    headers:
+      description: Headers to be merged into original request headers of graphql requests
+      type:
+        type: nullable
+        underlying_type:
+          type: named
+          name: _HeaderMap
+  relational_query_arguments: {}

--- a/crates/ndc-graphql/tests/snapshots/query_builder__config-1 NDC Schema.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__config-1 NDC Schema.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ndc-graphql/tests/query_builder.rs
+assertion_line: 105
 expression: schema
 ---
 scalar_types:
@@ -10,6 +11,7 @@ scalar_types:
         - PK_Album
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Album_select_column:
     representation:
       type: enum
@@ -19,6 +21,7 @@ scalar_types:
         - Title
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Album_update_column:
     representation:
       type: enum
@@ -27,6 +30,7 @@ scalar_types:
         - Title
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Artist_constraint:
     representation:
       type: enum
@@ -34,6 +38,7 @@ scalar_types:
         - PK_Artist
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Artist_select_column:
     representation:
       type: enum
@@ -42,6 +47,7 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Artist_update_column:
     representation:
       type: enum
@@ -49,9 +55,13 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Boolean:
+    representation:
+      type: boolean
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Customer_constraint:
     representation:
       type: enum
@@ -59,6 +69,7 @@ scalar_types:
         - PK_Customer
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Customer_select_column:
     representation:
       type: enum
@@ -78,6 +89,7 @@ scalar_types:
         - SupportRepId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Customer_update_column:
     representation:
       type: enum
@@ -96,6 +108,7 @@ scalar_types:
         - SupportRepId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Employee_constraint:
     representation:
       type: enum
@@ -103,6 +116,7 @@ scalar_types:
         - PK_Employee
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Employee_select_column:
     representation:
       type: enum
@@ -124,6 +138,7 @@ scalar_types:
         - Title
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Employee_update_column:
     representation:
       type: enum
@@ -144,9 +159,13 @@ scalar_types:
         - Title
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Float:
+    representation:
+      type: float64
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Genre_constraint:
     representation:
       type: enum
@@ -154,6 +173,7 @@ scalar_types:
         - PK_Genre
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Genre_select_column:
     representation:
       type: enum
@@ -162,6 +182,7 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Genre_update_column:
     representation:
       type: enum
@@ -169,9 +190,13 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Int:
+    representation:
+      type: int32
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   InvoiceLine_constraint:
     representation:
       type: enum
@@ -179,6 +204,7 @@ scalar_types:
         - PK_InvoiceLine
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   InvoiceLine_select_column:
     representation:
       type: enum
@@ -190,6 +216,7 @@ scalar_types:
         - UnitPrice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   InvoiceLine_update_column:
     representation:
       type: enum
@@ -200,6 +227,7 @@ scalar_types:
         - UnitPrice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Invoice_constraint:
     representation:
       type: enum
@@ -207,6 +235,7 @@ scalar_types:
         - PK_Invoice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Invoice_select_column:
     representation:
       type: enum
@@ -222,6 +251,7 @@ scalar_types:
         - Total
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Invoice_update_column:
     representation:
       type: enum
@@ -236,6 +266,7 @@ scalar_types:
         - Total
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   MediaType_constraint:
     representation:
       type: enum
@@ -243,6 +274,7 @@ scalar_types:
         - PK_MediaType
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   MediaType_select_column:
     representation:
       type: enum
@@ -251,6 +283,7 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   MediaType_update_column:
     representation:
       type: enum
@@ -258,6 +291,7 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   PlaylistTrack_constraint:
     representation:
       type: enum
@@ -265,6 +299,7 @@ scalar_types:
         - PK_PlaylistTrack
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   PlaylistTrack_select_column:
     representation:
       type: enum
@@ -273,6 +308,7 @@ scalar_types:
         - TrackId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   PlaylistTrack_update_column:
     representation:
       type: enum
@@ -281,6 +317,7 @@ scalar_types:
         - TrackId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Playlist_constraint:
     representation:
       type: enum
@@ -288,6 +325,7 @@ scalar_types:
         - PK_Playlist
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Playlist_select_column:
     representation:
       type: enum
@@ -296,6 +334,7 @@ scalar_types:
         - PlaylistId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Playlist_update_column:
     representation:
       type: enum
@@ -303,9 +342,13 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   String:
+    representation:
+      type: string
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Track_constraint:
     representation:
       type: enum
@@ -313,6 +356,7 @@ scalar_types:
         - PK_Track
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Track_select_column:
     representation:
       type: enum
@@ -328,6 +372,7 @@ scalar_types:
         - UnitPrice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Track_update_column:
     representation:
       type: enum
@@ -342,6 +387,7 @@ scalar_types:
         - UnitPrice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   cursor_ordering:
     representation:
       type: enum
@@ -350,9 +396,13 @@ scalar_types:
         - DESC
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   numeric:
+    representation:
+      type: json
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   order_by:
     representation:
       type: enum
@@ -365,9 +415,13 @@ scalar_types:
         - desc_nulls_last
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   timestamp:
+    representation:
+      type: json
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
 object_types:
   Album:
     description: "columns and relationships of \"Album\""
@@ -481,6 +535,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Track_bool_exp
+    foreign_keys: {}
   Album_aggregate:
     description: "aggregated selection of \"Album\""
     fields:
@@ -496,6 +551,7 @@ object_types:
           element_type:
             type: named
             name: Album
+    foreign_keys: {}
   Album_aggregate_bool_exp:
     fields:
       count:
@@ -504,6 +560,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_aggregate_bool_exp_count
+    foreign_keys: {}
   Album_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -530,6 +587,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Album_aggregate_fields:
     description: "aggregate fields of \"Album\""
     fields:
@@ -612,6 +670,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_variance_fields
+    foreign_keys: {}
   Album_aggregate_order_by:
     description: "order by aggregate values of table \"Album\""
     fields:
@@ -681,6 +740,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_variance_order_by
+    foreign_keys: {}
   Album_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Album\""
     fields:
@@ -697,6 +757,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_on_conflict
+    foreign_keys: {}
   Album_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -712,6 +773,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_avg_order_by:
     description: "order by avg() on columns of table \"Album\""
     fields:
@@ -727,6 +789,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_bool_exp:
     description: "Boolean expression to filter rows from the table \"Album\". All fields are combined with a logical 'AND'."
     fields:
@@ -788,6 +851,7 @@ object_types:
             element_type:
               type: named
               name: Album_bool_exp
+    foreign_keys: {}
   Album_inc_input:
     description: "input type for incrementing numeric columns in table \"Album\""
     fields:
@@ -797,6 +861,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Album_insert_input:
     description: "input type for inserting data into table \"Album\""
     fields:
@@ -824,6 +889,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_arr_rel_insert_input
+    foreign_keys: {}
   Album_max_fields:
     description: aggregate max on columns
     fields:
@@ -845,6 +911,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Album_max_order_by:
     description: "order by max() on columns of table \"Album\""
     fields:
@@ -866,6 +933,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_min_fields:
     description: aggregate min on columns
     fields:
@@ -887,6 +955,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Album_min_order_by:
     description: "order by min() on columns of table \"Album\""
     fields:
@@ -908,6 +977,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_mutation_response:
     description: "response of any mutation on the table \"Album\""
     fields:
@@ -923,6 +993,7 @@ object_types:
           element_type:
             type: named
             name: Album
+    foreign_keys: {}
   Album_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Album\""
     fields:
@@ -937,6 +1008,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_on_conflict
+    foreign_keys: {}
   Album_on_conflict:
     description: "on_conflict condition type for table \"Album\""
     fields:
@@ -956,6 +1028,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_bool_exp
+    foreign_keys: {}
   Album_order_by:
     description: "Ordering options when selecting data from \"Album\"."
     fields:
@@ -989,6 +1062,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_aggregate_order_by
+    foreign_keys: {}
   Album_pk_columns_input:
     description: "primary key columns input for table: Album"
     fields:
@@ -996,6 +1070,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Album_set_input:
     description: "input type for updating data in table \"Album\""
     fields:
@@ -1011,6 +1086,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Album_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -1026,6 +1102,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_stddev_order_by:
     description: "order by stddev() on columns of table \"Album\""
     fields:
@@ -1041,6 +1118,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -1056,6 +1134,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Album\""
     fields:
@@ -1071,6 +1150,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -1086,6 +1166,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Album\""
     fields:
@@ -1101,6 +1182,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_stream_cursor_input:
     description: "Streaming cursor of the table \"Album\""
     fields:
@@ -1116,6 +1198,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Album_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -1137,6 +1220,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Album_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -1152,6 +1236,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Album_sum_order_by:
     description: "order by sum() on columns of table \"Album\""
     fields:
@@ -1167,6 +1252,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_updates:
     fields:
       _inc:
@@ -1188,6 +1274,7 @@ object_types:
         type:
           type: named
           name: Album_bool_exp
+    foreign_keys: {}
   Album_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -1203,6 +1290,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Album\""
     fields:
@@ -1218,6 +1306,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -1233,6 +1322,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Album\""
     fields:
@@ -1248,6 +1338,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -1263,6 +1354,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_variance_order_by:
     description: "order by variance() on columns of table \"Album\""
     fields:
@@ -1278,6 +1370,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Artist:
     description: "columns and relationships of \"Artist\""
     fields:
@@ -1383,6 +1476,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_aggregate:
     description: "aggregated selection of \"Artist\""
     fields:
@@ -1398,6 +1492,7 @@ object_types:
           element_type:
             type: named
             name: Artist
+    foreign_keys: {}
   Artist_aggregate_fields:
     description: "aggregate fields of \"Artist\""
     fields:
@@ -1480,6 +1575,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_variance_fields
+    foreign_keys: {}
   Artist_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -1489,6 +1585,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_bool_exp:
     description: "Boolean expression to filter rows from the table \"Artist\". All fields are combined with a logical 'AND'."
     fields:
@@ -1538,6 +1635,7 @@ object_types:
             element_type:
               type: named
               name: Artist_bool_exp
+    foreign_keys: {}
   Artist_insert_input:
     description: "input type for inserting data into table \"Artist\""
     fields:
@@ -1553,6 +1651,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_max_fields:
     description: aggregate max on columns
     fields:
@@ -1568,6 +1667,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_min_fields:
     description: aggregate min on columns
     fields:
@@ -1583,6 +1683,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_mutation_response:
     description: "response of any mutation on the table \"Artist\""
     fields:
@@ -1598,6 +1699,7 @@ object_types:
           element_type:
             type: named
             name: Artist
+    foreign_keys: {}
   Artist_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Artist\""
     fields:
@@ -1612,6 +1714,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_on_conflict
+    foreign_keys: {}
   Artist_on_conflict:
     description: "on_conflict condition type for table \"Artist\""
     fields:
@@ -1631,6 +1734,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_bool_exp
+    foreign_keys: {}
   Artist_order_by:
     description: "Ordering options when selecting data from \"Artist\"."
     fields:
@@ -1652,6 +1756,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Artist_pk_columns_input:
     description: "primary key columns input for table: Artist"
     fields:
@@ -1659,6 +1764,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Artist_set_input:
     description: "input type for updating data in table \"Artist\""
     fields:
@@ -1668,6 +1774,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -1677,6 +1784,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -1686,6 +1794,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -1695,6 +1804,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_stream_cursor_input:
     description: "Streaming cursor of the table \"Artist\""
     fields:
@@ -1710,6 +1820,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Artist_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -1725,6 +1836,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -1734,6 +1846,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Artist_updates:
     fields:
       _set:
@@ -1748,6 +1861,7 @@ object_types:
         type:
           type: named
           name: Artist_bool_exp
+    foreign_keys: {}
   Artist_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -1757,6 +1871,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -1766,6 +1881,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -1775,6 +1891,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer:
     description: "columns and relationships of \"Customer\""
     fields:
@@ -1947,6 +2064,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_aggregate:
     description: "aggregated selection of \"Customer\""
     fields:
@@ -1962,6 +2080,7 @@ object_types:
           element_type:
             type: named
             name: Customer
+    foreign_keys: {}
   Customer_aggregate_bool_exp:
     fields:
       count:
@@ -1970,6 +2089,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_aggregate_bool_exp_count
+    foreign_keys: {}
   Customer_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -1996,6 +2116,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Customer_aggregate_fields:
     description: "aggregate fields of \"Customer\""
     fields:
@@ -2078,6 +2199,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_variance_fields
+    foreign_keys: {}
   Customer_aggregate_order_by:
     description: "order by aggregate values of table \"Customer\""
     fields:
@@ -2147,6 +2269,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_variance_order_by
+    foreign_keys: {}
   Customer_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Customer\""
     fields:
@@ -2163,6 +2286,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_on_conflict
+    foreign_keys: {}
   Customer_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -2178,6 +2302,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_avg_order_by:
     description: "order by avg() on columns of table \"Customer\""
     fields:
@@ -2193,6 +2318,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_bool_exp:
     description: "Boolean expression to filter rows from the table \"Customer\". All fields are combined with a logical 'AND'."
     fields:
@@ -2314,6 +2440,7 @@ object_types:
             element_type:
               type: named
               name: Customer_bool_exp
+    foreign_keys: {}
   Customer_inc_input:
     description: "input type for incrementing numeric columns in table \"Customer\""
     fields:
@@ -2323,6 +2450,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_insert_input:
     description: "input type for inserting data into table \"Customer\""
     fields:
@@ -2410,6 +2538,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_max_fields:
     description: aggregate max on columns
     fields:
@@ -2491,6 +2620,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_max_order_by:
     description: "order by max() on columns of table \"Customer\""
     fields:
@@ -2572,6 +2702,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_min_fields:
     description: aggregate min on columns
     fields:
@@ -2653,6 +2784,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_min_order_by:
     description: "order by min() on columns of table \"Customer\""
     fields:
@@ -2734,6 +2866,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_mutation_response:
     description: "response of any mutation on the table \"Customer\""
     fields:
@@ -2749,6 +2882,7 @@ object_types:
           element_type:
             type: named
             name: Customer
+    foreign_keys: {}
   Customer_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Customer\""
     fields:
@@ -2763,6 +2897,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_on_conflict
+    foreign_keys: {}
   Customer_on_conflict:
     description: "on_conflict condition type for table \"Customer\""
     fields:
@@ -2782,6 +2917,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_bool_exp
+    foreign_keys: {}
   Customer_order_by:
     description: "Ordering options when selecting data from \"Customer\"."
     fields:
@@ -2875,6 +3011,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_pk_columns_input:
     description: "primary key columns input for table: Customer"
     fields:
@@ -2882,6 +3019,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Customer_set_input:
     description: "input type for updating data in table \"Customer\""
     fields:
@@ -2957,6 +3095,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -2972,6 +3111,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_stddev_order_by:
     description: "order by stddev() on columns of table \"Customer\""
     fields:
@@ -2987,6 +3127,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -3002,6 +3143,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Customer\""
     fields:
@@ -3017,6 +3159,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -3032,6 +3175,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Customer\""
     fields:
@@ -3047,6 +3191,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_stream_cursor_input:
     description: "Streaming cursor of the table \"Customer\""
     fields:
@@ -3062,6 +3207,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Customer_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -3143,6 +3289,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -3158,6 +3305,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_sum_order_by:
     description: "order by sum() on columns of table \"Customer\""
     fields:
@@ -3173,6 +3321,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_updates:
     fields:
       _inc:
@@ -3194,6 +3343,7 @@ object_types:
         type:
           type: named
           name: Customer_bool_exp
+    foreign_keys: {}
   Customer_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -3209,6 +3359,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Customer\""
     fields:
@@ -3224,6 +3375,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -3239,6 +3391,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Customer\""
     fields:
@@ -3254,6 +3407,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -3269,6 +3423,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_variance_order_by:
     description: "order by variance() on columns of table \"Customer\""
     fields:
@@ -3284,6 +3439,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee:
     description: "columns and relationships of \"Employee\""
     fields:
@@ -3562,6 +3718,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_aggregate:
     description: "aggregated selection of \"Employee\""
     fields:
@@ -3577,6 +3734,7 @@ object_types:
           element_type:
             type: named
             name: Employee
+    foreign_keys: {}
   Employee_aggregate_bool_exp:
     fields:
       count:
@@ -3585,6 +3743,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_aggregate_bool_exp_count
+    foreign_keys: {}
   Employee_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -3611,6 +3770,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Employee_aggregate_fields:
     description: "aggregate fields of \"Employee\""
     fields:
@@ -3693,6 +3853,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_variance_fields
+    foreign_keys: {}
   Employee_aggregate_order_by:
     description: "order by aggregate values of table \"Employee\""
     fields:
@@ -3762,6 +3923,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_variance_order_by
+    foreign_keys: {}
   Employee_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Employee\""
     fields:
@@ -3778,6 +3940,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_on_conflict
+    foreign_keys: {}
   Employee_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -3793,6 +3956,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_avg_order_by:
     description: "order by avg() on columns of table \"Employee\""
     fields:
@@ -3808,6 +3972,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_bool_exp:
     description: "Boolean expression to filter rows from the table \"Employee\". All fields are combined with a logical 'AND'."
     fields:
@@ -3953,6 +4118,7 @@ object_types:
             element_type:
               type: named
               name: Employee_bool_exp
+    foreign_keys: {}
   Employee_inc_input:
     description: "input type for incrementing numeric columns in table \"Employee\""
     fields:
@@ -3962,6 +4128,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Employee_insert_input:
     description: "input type for inserting data into table \"Employee\""
     fields:
@@ -4067,6 +4234,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_max_fields:
     description: aggregate max on columns
     fields:
@@ -4160,6 +4328,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_max_order_by:
     description: "order by max() on columns of table \"Employee\""
     fields:
@@ -4253,6 +4422,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_min_fields:
     description: aggregate min on columns
     fields:
@@ -4346,6 +4516,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_min_order_by:
     description: "order by min() on columns of table \"Employee\""
     fields:
@@ -4439,6 +4610,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_mutation_response:
     description: "response of any mutation on the table \"Employee\""
     fields:
@@ -4454,6 +4626,7 @@ object_types:
           element_type:
             type: named
             name: Employee
+    foreign_keys: {}
   Employee_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Employee\""
     fields:
@@ -4468,6 +4641,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_on_conflict
+    foreign_keys: {}
   Employee_on_conflict:
     description: "on_conflict condition type for table \"Employee\""
     fields:
@@ -4487,6 +4661,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_bool_exp
+    foreign_keys: {}
   Employee_order_by:
     description: "Ordering options when selecting data from \"Employee\"."
     fields:
@@ -4598,6 +4773,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_pk_columns_input:
     description: "primary key columns input for table: Employee"
     fields:
@@ -4605,6 +4781,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Employee_set_input:
     description: "input type for updating data in table \"Employee\""
     fields:
@@ -4692,6 +4869,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -4707,6 +4885,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_stddev_order_by:
     description: "order by stddev() on columns of table \"Employee\""
     fields:
@@ -4722,6 +4901,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -4737,6 +4917,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Employee\""
     fields:
@@ -4752,6 +4933,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -4767,6 +4949,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Employee\""
     fields:
@@ -4782,6 +4965,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_stream_cursor_input:
     description: "Streaming cursor of the table \"Employee\""
     fields:
@@ -4797,6 +4981,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Employee_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -4890,6 +5075,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -4905,6 +5091,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Employee_sum_order_by:
     description: "order by sum() on columns of table \"Employee\""
     fields:
@@ -4920,6 +5107,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_updates:
     fields:
       _inc:
@@ -4941,6 +5129,7 @@ object_types:
         type:
           type: named
           name: Employee_bool_exp
+    foreign_keys: {}
   Employee_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -4956,6 +5145,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Employee\""
     fields:
@@ -4971,6 +5161,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -4986,6 +5177,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Employee\""
     fields:
@@ -5001,6 +5193,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -5016,6 +5209,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_variance_order_by:
     description: "order by variance() on columns of table \"Employee\""
     fields:
@@ -5031,6 +5225,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Genre:
     description: "columns and relationships of \"Genre\""
     fields:
@@ -5136,6 +5331,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Track_bool_exp
+    foreign_keys: {}
   Genre_aggregate:
     description: "aggregated selection of \"Genre\""
     fields:
@@ -5151,6 +5347,7 @@ object_types:
           element_type:
             type: named
             name: Genre
+    foreign_keys: {}
   Genre_aggregate_fields:
     description: "aggregate fields of \"Genre\""
     fields:
@@ -5233,6 +5430,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_variance_fields
+    foreign_keys: {}
   Genre_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -5242,6 +5440,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_bool_exp:
     description: "Boolean expression to filter rows from the table \"Genre\". All fields are combined with a logical 'AND'."
     fields:
@@ -5291,6 +5490,7 @@ object_types:
             element_type:
               type: named
               name: Genre_bool_exp
+    foreign_keys: {}
   Genre_insert_input:
     description: "input type for inserting data into table \"Genre\""
     fields:
@@ -5306,6 +5506,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_arr_rel_insert_input
+    foreign_keys: {}
   Genre_max_fields:
     description: aggregate max on columns
     fields:
@@ -5321,6 +5522,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Genre_min_fields:
     description: aggregate min on columns
     fields:
@@ -5336,6 +5538,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Genre_mutation_response:
     description: "response of any mutation on the table \"Genre\""
     fields:
@@ -5351,6 +5554,7 @@ object_types:
           element_type:
             type: named
             name: Genre
+    foreign_keys: {}
   Genre_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Genre\""
     fields:
@@ -5365,6 +5569,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_on_conflict
+    foreign_keys: {}
   Genre_on_conflict:
     description: "on_conflict condition type for table \"Genre\""
     fields:
@@ -5384,6 +5589,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_bool_exp
+    foreign_keys: {}
   Genre_order_by:
     description: "Ordering options when selecting data from \"Genre\"."
     fields:
@@ -5405,6 +5611,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_aggregate_order_by
+    foreign_keys: {}
   Genre_pk_columns_input:
     description: "primary key columns input for table: Genre"
     fields:
@@ -5412,6 +5619,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Genre_set_input:
     description: "input type for updating data in table \"Genre\""
     fields:
@@ -5421,6 +5629,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Genre_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -5430,6 +5639,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -5439,6 +5649,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -5448,6 +5659,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_stream_cursor_input:
     description: "Streaming cursor of the table \"Genre\""
     fields:
@@ -5463,6 +5675,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Genre_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -5478,6 +5691,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Genre_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -5487,6 +5701,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Genre_updates:
     fields:
       _set:
@@ -5501,6 +5716,7 @@ object_types:
         type:
           type: named
           name: Genre_bool_exp
+    foreign_keys: {}
   Genre_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -5510,6 +5726,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -5519,6 +5736,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -5528,6 +5746,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Int_comparison_exp:
     description: "Boolean expression to compare columns of type \"Int\". All fields are combined with logical 'AND'."
     fields:
@@ -5589,6 +5808,7 @@ object_types:
             element_type:
               type: named
               name: Int
+    foreign_keys: {}
   Invoice:
     description: "columns and relationships of \"Invoice\""
     fields:
@@ -5735,6 +5955,7 @@ object_types:
         type:
           type: named
           name: numeric
+    foreign_keys: {}
   InvoiceLine:
     description: "columns and relationships of \"InvoiceLine\""
     fields:
@@ -5768,6 +5989,7 @@ object_types:
         type:
           type: named
           name: numeric
+    foreign_keys: {}
   InvoiceLine_aggregate:
     description: "aggregated selection of \"InvoiceLine\""
     fields:
@@ -5783,6 +6005,7 @@ object_types:
           element_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   InvoiceLine_aggregate_bool_exp:
     fields:
       count:
@@ -5791,6 +6014,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_aggregate_bool_exp_count
+    foreign_keys: {}
   InvoiceLine_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -5817,6 +6041,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   InvoiceLine_aggregate_fields:
     description: "aggregate fields of \"InvoiceLine\""
     fields:
@@ -5899,6 +6124,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_variance_fields
+    foreign_keys: {}
   InvoiceLine_aggregate_order_by:
     description: "order by aggregate values of table \"InvoiceLine\""
     fields:
@@ -5968,6 +6194,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_variance_order_by
+    foreign_keys: {}
   InvoiceLine_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"InvoiceLine\""
     fields:
@@ -5984,6 +6211,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_on_conflict
+    foreign_keys: {}
   InvoiceLine_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -6017,6 +6245,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_avg_order_by:
     description: "order by avg() on columns of table \"InvoiceLine\""
     fields:
@@ -6050,6 +6279,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_bool_exp:
     description: "Boolean expression to filter rows from the table \"InvoiceLine\". All fields are combined with a logical 'AND'."
     fields:
@@ -6117,6 +6347,7 @@ object_types:
             element_type:
               type: named
               name: InvoiceLine_bool_exp
+    foreign_keys: {}
   InvoiceLine_inc_input:
     description: "input type for incrementing numeric columns in table \"InvoiceLine\""
     fields:
@@ -6144,6 +6375,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_insert_input:
     description: "input type for inserting data into table \"InvoiceLine\""
     fields:
@@ -6183,6 +6415,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_max_fields:
     description: aggregate max on columns
     fields:
@@ -6216,6 +6449,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_max_order_by:
     description: "order by max() on columns of table \"InvoiceLine\""
     fields:
@@ -6249,6 +6483,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_min_fields:
     description: aggregate min on columns
     fields:
@@ -6282,6 +6517,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_min_order_by:
     description: "order by min() on columns of table \"InvoiceLine\""
     fields:
@@ -6315,6 +6551,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_mutation_response:
     description: "response of any mutation on the table \"InvoiceLine\""
     fields:
@@ -6330,6 +6567,7 @@ object_types:
           element_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   InvoiceLine_on_conflict:
     description: "on_conflict condition type for table \"InvoiceLine\""
     fields:
@@ -6349,6 +6587,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_bool_exp
+    foreign_keys: {}
   InvoiceLine_order_by:
     description: "Ordering options when selecting data from \"InvoiceLine\"."
     fields:
@@ -6394,6 +6633,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_pk_columns_input:
     description: "primary key columns input for table: InvoiceLine"
     fields:
@@ -6401,6 +6641,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   InvoiceLine_set_input:
     description: "input type for updating data in table \"InvoiceLine\""
     fields:
@@ -6428,6 +6669,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -6461,6 +6703,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_stddev_order_by:
     description: "order by stddev() on columns of table \"InvoiceLine\""
     fields:
@@ -6494,6 +6737,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -6527,6 +6771,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"InvoiceLine\""
     fields:
@@ -6560,6 +6805,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -6593,6 +6839,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"InvoiceLine\""
     fields:
@@ -6626,6 +6873,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_stream_cursor_input:
     description: "Streaming cursor of the table \"InvoiceLine\""
     fields:
@@ -6641,6 +6889,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   InvoiceLine_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -6674,6 +6923,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -6707,6 +6957,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_sum_order_by:
     description: "order by sum() on columns of table \"InvoiceLine\""
     fields:
@@ -6740,6 +6991,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_updates:
     fields:
       _inc:
@@ -6761,6 +7013,7 @@ object_types:
         type:
           type: named
           name: InvoiceLine_bool_exp
+    foreign_keys: {}
   InvoiceLine_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -6794,6 +7047,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_var_pop_order_by:
     description: "order by var_pop() on columns of table \"InvoiceLine\""
     fields:
@@ -6827,6 +7081,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -6860,6 +7115,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_var_samp_order_by:
     description: "order by var_samp() on columns of table \"InvoiceLine\""
     fields:
@@ -6893,6 +7149,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -6926,6 +7183,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_variance_order_by:
     description: "order by variance() on columns of table \"InvoiceLine\""
     fields:
@@ -6959,6 +7217,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_aggregate:
     description: "aggregated selection of \"Invoice\""
     fields:
@@ -6974,6 +7233,7 @@ object_types:
           element_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   Invoice_aggregate_bool_exp:
     fields:
       count:
@@ -6982,6 +7242,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_aggregate_bool_exp_count
+    foreign_keys: {}
   Invoice_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -7008,6 +7269,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Invoice_aggregate_fields:
     description: "aggregate fields of \"Invoice\""
     fields:
@@ -7090,6 +7352,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_variance_fields
+    foreign_keys: {}
   Invoice_aggregate_order_by:
     description: "order by aggregate values of table \"Invoice\""
     fields:
@@ -7159,6 +7422,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_variance_order_by
+    foreign_keys: {}
   Invoice_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Invoice\""
     fields:
@@ -7175,6 +7439,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_on_conflict
+    foreign_keys: {}
   Invoice_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -7196,6 +7461,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_avg_order_by:
     description: "order by avg() on columns of table \"Invoice\""
     fields:
@@ -7217,6 +7483,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_bool_exp:
     description: "Boolean expression to filter rows from the table \"Invoice\". All fields are combined with a logical 'AND'."
     fields:
@@ -7314,6 +7581,7 @@ object_types:
             element_type:
               type: named
               name: Invoice_bool_exp
+    foreign_keys: {}
   Invoice_inc_input:
     description: "input type for incrementing numeric columns in table \"Invoice\""
     fields:
@@ -7329,6 +7597,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_insert_input:
     description: "input type for inserting data into table \"Invoice\""
     fields:
@@ -7392,6 +7661,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_max_fields:
     description: aggregate max on columns
     fields:
@@ -7449,6 +7719,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_max_order_by:
     description: "order by max() on columns of table \"Invoice\""
     fields:
@@ -7506,6 +7777,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_min_fields:
     description: aggregate min on columns
     fields:
@@ -7563,6 +7835,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_min_order_by:
     description: "order by min() on columns of table \"Invoice\""
     fields:
@@ -7620,6 +7893,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_mutation_response:
     description: "response of any mutation on the table \"Invoice\""
     fields:
@@ -7635,6 +7909,7 @@ object_types:
           element_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   Invoice_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Invoice\""
     fields:
@@ -7649,6 +7924,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_on_conflict
+    foreign_keys: {}
   Invoice_on_conflict:
     description: "on_conflict condition type for table \"Invoice\""
     fields:
@@ -7668,6 +7944,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_bool_exp
+    foreign_keys: {}
   Invoice_order_by:
     description: "Ordering options when selecting data from \"Invoice\"."
     fields:
@@ -7737,6 +8014,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_pk_columns_input:
     description: "primary key columns input for table: Invoice"
     fields:
@@ -7744,6 +8022,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Invoice_set_input:
     description: "input type for updating data in table \"Invoice\""
     fields:
@@ -7795,6 +8074,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -7816,6 +8096,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_stddev_order_by:
     description: "order by stddev() on columns of table \"Invoice\""
     fields:
@@ -7837,6 +8118,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -7858,6 +8140,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Invoice\""
     fields:
@@ -7879,6 +8162,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -7900,6 +8184,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Invoice\""
     fields:
@@ -7921,6 +8206,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_stream_cursor_input:
     description: "Streaming cursor of the table \"Invoice\""
     fields:
@@ -7936,6 +8222,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Invoice_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -7993,6 +8280,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -8014,6 +8302,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_sum_order_by:
     description: "order by sum() on columns of table \"Invoice\""
     fields:
@@ -8035,6 +8324,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_updates:
     fields:
       _inc:
@@ -8056,6 +8346,7 @@ object_types:
         type:
           type: named
           name: Invoice_bool_exp
+    foreign_keys: {}
   Invoice_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -8077,6 +8368,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Invoice\""
     fields:
@@ -8098,6 +8390,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -8119,6 +8412,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Invoice\""
     fields:
@@ -8140,6 +8434,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -8161,6 +8456,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_variance_order_by:
     description: "order by variance() on columns of table \"Invoice\""
     fields:
@@ -8182,6 +8478,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   MediaType:
     description: "columns and relationships of \"MediaType\""
     fields:
@@ -8287,6 +8584,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Track_bool_exp
+    foreign_keys: {}
   MediaType_aggregate:
     description: "aggregated selection of \"MediaType\""
     fields:
@@ -8302,6 +8600,7 @@ object_types:
           element_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   MediaType_aggregate_fields:
     description: "aggregate fields of \"MediaType\""
     fields:
@@ -8384,6 +8683,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_variance_fields
+    foreign_keys: {}
   MediaType_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -8393,6 +8693,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_bool_exp:
     description: "Boolean expression to filter rows from the table \"MediaType\". All fields are combined with a logical 'AND'."
     fields:
@@ -8442,6 +8743,7 @@ object_types:
             element_type:
               type: named
               name: MediaType_bool_exp
+    foreign_keys: {}
   MediaType_insert_input:
     description: "input type for inserting data into table \"MediaType\""
     fields:
@@ -8457,6 +8759,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_arr_rel_insert_input
+    foreign_keys: {}
   MediaType_max_fields:
     description: aggregate max on columns
     fields:
@@ -8472,6 +8775,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   MediaType_min_fields:
     description: aggregate min on columns
     fields:
@@ -8487,6 +8791,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   MediaType_mutation_response:
     description: "response of any mutation on the table \"MediaType\""
     fields:
@@ -8502,6 +8807,7 @@ object_types:
           element_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   MediaType_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"MediaType\""
     fields:
@@ -8516,6 +8822,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_on_conflict
+    foreign_keys: {}
   MediaType_on_conflict:
     description: "on_conflict condition type for table \"MediaType\""
     fields:
@@ -8535,6 +8842,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_bool_exp
+    foreign_keys: {}
   MediaType_order_by:
     description: "Ordering options when selecting data from \"MediaType\"."
     fields:
@@ -8556,6 +8864,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_aggregate_order_by
+    foreign_keys: {}
   MediaType_pk_columns_input:
     description: "primary key columns input for table: MediaType"
     fields:
@@ -8563,6 +8872,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   MediaType_set_input:
     description: "input type for updating data in table \"MediaType\""
     fields:
@@ -8572,6 +8882,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   MediaType_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -8581,6 +8892,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -8590,6 +8902,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -8599,6 +8912,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_stream_cursor_input:
     description: "Streaming cursor of the table \"MediaType\""
     fields:
@@ -8614,6 +8928,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   MediaType_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -8629,6 +8944,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   MediaType_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -8638,6 +8954,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   MediaType_updates:
     fields:
       _set:
@@ -8652,6 +8969,7 @@ object_types:
         type:
           type: named
           name: MediaType_bool_exp
+    foreign_keys: {}
   MediaType_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -8661,6 +8979,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -8670,6 +8989,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -8679,6 +8999,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist:
     description: "columns and relationships of \"Playlist\""
     fields:
@@ -8784,6 +9105,7 @@ object_types:
               underlying_type:
                 type: named
                 name: PlaylistTrack_bool_exp
+    foreign_keys: {}
   PlaylistTrack:
     description: "columns and relationships of \"PlaylistTrack\""
     fields:
@@ -8805,6 +9127,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   PlaylistTrack_aggregate:
     description: "aggregated selection of \"PlaylistTrack\""
     fields:
@@ -8820,6 +9143,7 @@ object_types:
           element_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   PlaylistTrack_aggregate_bool_exp:
     fields:
       count:
@@ -8828,6 +9152,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_aggregate_bool_exp_count
+    foreign_keys: {}
   PlaylistTrack_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -8854,6 +9179,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   PlaylistTrack_aggregate_fields:
     description: "aggregate fields of \"PlaylistTrack\""
     fields:
@@ -8936,6 +9262,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_variance_fields
+    foreign_keys: {}
   PlaylistTrack_aggregate_order_by:
     description: "order by aggregate values of table \"PlaylistTrack\""
     fields:
@@ -9005,6 +9332,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_variance_order_by
+    foreign_keys: {}
   PlaylistTrack_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"PlaylistTrack\""
     fields:
@@ -9021,6 +9349,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_on_conflict
+    foreign_keys: {}
   PlaylistTrack_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -9036,6 +9365,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_avg_order_by:
     description: "order by avg() on columns of table \"PlaylistTrack\""
     fields:
@@ -9051,6 +9381,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_bool_exp:
     description: "Boolean expression to filter rows from the table \"PlaylistTrack\". All fields are combined with a logical 'AND'."
     fields:
@@ -9100,6 +9431,7 @@ object_types:
             element_type:
               type: named
               name: PlaylistTrack_bool_exp
+    foreign_keys: {}
   PlaylistTrack_inc_input:
     description: "input type for incrementing numeric columns in table \"PlaylistTrack\""
     fields:
@@ -9115,6 +9447,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_insert_input:
     description: "input type for inserting data into table \"PlaylistTrack\""
     fields:
@@ -9142,6 +9475,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_max_fields:
     description: aggregate max on columns
     fields:
@@ -9157,6 +9491,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_max_order_by:
     description: "order by max() on columns of table \"PlaylistTrack\""
     fields:
@@ -9172,6 +9507,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_min_fields:
     description: aggregate min on columns
     fields:
@@ -9187,6 +9523,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_min_order_by:
     description: "order by min() on columns of table \"PlaylistTrack\""
     fields:
@@ -9202,6 +9539,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_mutation_response:
     description: "response of any mutation on the table \"PlaylistTrack\""
     fields:
@@ -9217,6 +9555,7 @@ object_types:
           element_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   PlaylistTrack_on_conflict:
     description: "on_conflict condition type for table \"PlaylistTrack\""
     fields:
@@ -9236,6 +9575,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_bool_exp
+    foreign_keys: {}
   PlaylistTrack_order_by:
     description: "Ordering options when selecting data from \"PlaylistTrack\"."
     fields:
@@ -9263,6 +9603,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_pk_columns_input:
     description: "primary key columns input for table: PlaylistTrack"
     fields:
@@ -9274,6 +9615,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   PlaylistTrack_set_input:
     description: "input type for updating data in table \"PlaylistTrack\""
     fields:
@@ -9289,6 +9631,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -9304,6 +9647,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_stddev_order_by:
     description: "order by stddev() on columns of table \"PlaylistTrack\""
     fields:
@@ -9319,6 +9663,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -9334,6 +9679,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"PlaylistTrack\""
     fields:
@@ -9349,6 +9695,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -9364,6 +9711,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"PlaylistTrack\""
     fields:
@@ -9379,6 +9727,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_stream_cursor_input:
     description: "Streaming cursor of the table \"PlaylistTrack\""
     fields:
@@ -9394,6 +9743,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   PlaylistTrack_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -9409,6 +9759,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -9424,6 +9775,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_sum_order_by:
     description: "order by sum() on columns of table \"PlaylistTrack\""
     fields:
@@ -9439,6 +9791,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_updates:
     fields:
       _inc:
@@ -9460,6 +9813,7 @@ object_types:
         type:
           type: named
           name: PlaylistTrack_bool_exp
+    foreign_keys: {}
   PlaylistTrack_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -9475,6 +9829,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_var_pop_order_by:
     description: "order by var_pop() on columns of table \"PlaylistTrack\""
     fields:
@@ -9490,6 +9845,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -9505,6 +9861,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_var_samp_order_by:
     description: "order by var_samp() on columns of table \"PlaylistTrack\""
     fields:
@@ -9520,6 +9877,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -9535,6 +9893,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_variance_order_by:
     description: "order by variance() on columns of table \"PlaylistTrack\""
     fields:
@@ -9550,6 +9909,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Playlist_aggregate:
     description: "aggregated selection of \"Playlist\""
     fields:
@@ -9565,6 +9925,7 @@ object_types:
           element_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   Playlist_aggregate_fields:
     description: "aggregate fields of \"Playlist\""
     fields:
@@ -9647,6 +10008,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_variance_fields
+    foreign_keys: {}
   Playlist_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -9656,6 +10018,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_bool_exp:
     description: "Boolean expression to filter rows from the table \"Playlist\". All fields are combined with a logical 'AND'."
     fields:
@@ -9705,6 +10068,7 @@ object_types:
             element_type:
               type: named
               name: Playlist_bool_exp
+    foreign_keys: {}
   Playlist_insert_input:
     description: "input type for inserting data into table \"Playlist\""
     fields:
@@ -9720,6 +10084,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_arr_rel_insert_input
+    foreign_keys: {}
   Playlist_max_fields:
     description: aggregate max on columns
     fields:
@@ -9735,6 +10100,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Playlist_min_fields:
     description: aggregate min on columns
     fields:
@@ -9750,6 +10116,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Playlist_mutation_response:
     description: "response of any mutation on the table \"Playlist\""
     fields:
@@ -9765,6 +10132,7 @@ object_types:
           element_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   Playlist_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Playlist\""
     fields:
@@ -9779,6 +10147,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_on_conflict
+    foreign_keys: {}
   Playlist_on_conflict:
     description: "on_conflict condition type for table \"Playlist\""
     fields:
@@ -9798,6 +10167,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_bool_exp
+    foreign_keys: {}
   Playlist_order_by:
     description: "Ordering options when selecting data from \"Playlist\"."
     fields:
@@ -9819,6 +10189,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_aggregate_order_by
+    foreign_keys: {}
   Playlist_pk_columns_input:
     description: "primary key columns input for table: Playlist"
     fields:
@@ -9826,6 +10197,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Playlist_set_input:
     description: "input type for updating data in table \"Playlist\""
     fields:
@@ -9835,6 +10207,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Playlist_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -9844,6 +10217,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -9853,6 +10227,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -9862,6 +10237,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_stream_cursor_input:
     description: "Streaming cursor of the table \"Playlist\""
     fields:
@@ -9877,6 +10253,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Playlist_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -9892,6 +10269,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Playlist_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -9901,6 +10279,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Playlist_updates:
     fields:
       _set:
@@ -9915,6 +10294,7 @@ object_types:
         type:
           type: named
           name: Playlist_bool_exp
+    foreign_keys: {}
   Playlist_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -9924,6 +10304,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -9933,6 +10314,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -9942,6 +10324,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   String_comparison_exp:
     description: "Boolean expression to compare columns of type \"String\". All fields are combined with logical 'AND'."
     fields:
@@ -10073,6 +10456,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Track:
     description: "columns and relationships of \"Track\""
     fields:
@@ -10323,6 +10707,7 @@ object_types:
         type:
           type: named
           name: numeric
+    foreign_keys: {}
   Track_aggregate:
     description: "aggregated selection of \"Track\""
     fields:
@@ -10338,6 +10723,7 @@ object_types:
           element_type:
             type: named
             name: Track
+    foreign_keys: {}
   Track_aggregate_bool_exp:
     fields:
       count:
@@ -10346,6 +10732,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_aggregate_bool_exp_count
+    foreign_keys: {}
   Track_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -10372,6 +10759,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Track_aggregate_fields:
     description: "aggregate fields of \"Track\""
     fields:
@@ -10454,6 +10842,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_variance_fields
+    foreign_keys: {}
   Track_aggregate_order_by:
     description: "order by aggregate values of table \"Track\""
     fields:
@@ -10523,6 +10912,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_variance_order_by
+    foreign_keys: {}
   Track_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Track\""
     fields:
@@ -10539,6 +10929,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_on_conflict
+    foreign_keys: {}
   Track_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -10584,6 +10975,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_avg_order_by:
     description: "order by avg() on columns of table \"Track\""
     fields:
@@ -10629,6 +11021,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_bool_exp:
     description: "Boolean expression to filter rows from the table \"Track\". All fields are combined with a logical 'AND'."
     fields:
@@ -10750,6 +11143,7 @@ object_types:
             element_type:
               type: named
               name: Track_bool_exp
+    foreign_keys: {}
   Track_inc_input:
     description: "input type for incrementing numeric columns in table \"Track\""
     fields:
@@ -10789,6 +11183,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_insert_input:
     description: "input type for inserting data into table \"Track\""
     fields:
@@ -10870,6 +11265,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_max_fields:
     description: aggregate max on columns
     fields:
@@ -10927,6 +11323,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_max_order_by:
     description: "order by max() on columns of table \"Track\""
     fields:
@@ -10984,6 +11381,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_min_fields:
     description: aggregate min on columns
     fields:
@@ -11041,6 +11439,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_min_order_by:
     description: "order by min() on columns of table \"Track\""
     fields:
@@ -11098,6 +11497,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_mutation_response:
     description: "response of any mutation on the table \"Track\""
     fields:
@@ -11113,6 +11513,7 @@ object_types:
           element_type:
             type: named
             name: Track
+    foreign_keys: {}
   Track_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Track\""
     fields:
@@ -11127,6 +11528,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_on_conflict
+    foreign_keys: {}
   Track_on_conflict:
     description: "on_conflict condition type for table \"Track\""
     fields:
@@ -11146,6 +11548,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_bool_exp
+    foreign_keys: {}
   Track_order_by:
     description: "Ordering options when selecting data from \"Track\"."
     fields:
@@ -11233,6 +11636,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_pk_columns_input:
     description: "primary key columns input for table: Track"
     fields:
@@ -11240,6 +11644,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Track_set_input:
     description: "input type for updating data in table \"Track\""
     fields:
@@ -11291,6 +11696,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -11336,6 +11742,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_stddev_order_by:
     description: "order by stddev() on columns of table \"Track\""
     fields:
@@ -11381,6 +11788,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -11426,6 +11834,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Track\""
     fields:
@@ -11471,6 +11880,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -11516,6 +11926,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Track\""
     fields:
@@ -11561,6 +11972,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_stream_cursor_input:
     description: "Streaming cursor of the table \"Track\""
     fields:
@@ -11576,6 +11988,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Track_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -11633,6 +12046,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -11678,6 +12092,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_sum_order_by:
     description: "order by sum() on columns of table \"Track\""
     fields:
@@ -11723,6 +12138,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_updates:
     fields:
       _inc:
@@ -11744,6 +12160,7 @@ object_types:
         type:
           type: named
           name: Track_bool_exp
+    foreign_keys: {}
   Track_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -11789,6 +12206,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Track\""
     fields:
@@ -11834,6 +12252,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -11879,6 +12298,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Track\""
     fields:
@@ -11924,6 +12344,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -11969,6 +12390,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_variance_order_by:
     description: "order by variance() on columns of table \"Track\""
     fields:
@@ -12014,6 +12436,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   numeric_comparison_exp:
     description: "Boolean expression to compare columns of type \"numeric\". All fields are combined with logical 'AND'."
     fields:
@@ -12075,6 +12498,7 @@ object_types:
             element_type:
               type: named
               name: numeric
+    foreign_keys: {}
   subscription_root:
     fields:
       Album:
@@ -13544,6 +13968,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Track_bool_exp
+    foreign_keys: {}
   timestamp_comparison_exp:
     description: "Boolean expression to compare columns of type \"timestamp\". All fields are combined with logical 'AND'."
     fields:
@@ -13605,6 +14030,7 @@ object_types:
             element_type:
               type: named
               name: timestamp
+    foreign_keys: {}
 collections: []
 functions:
   - name: Album
@@ -16233,3 +16659,5 @@ procedures:
           underlying_type:
             type: named
             name: Track_mutation_response
+capabilities: ~
+request_arguments: ~

--- a/crates/ndc-graphql/tests/snapshots/query_builder__config-2 NDC Schema.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__config-2 NDC Schema.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ndc-graphql/tests/query_builder.rs
+assertion_line: 105
 expression: schema
 ---
 scalar_types:
@@ -10,6 +11,7 @@ scalar_types:
         - PK_Album
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Album_select_column:
     representation:
       type: enum
@@ -19,6 +21,7 @@ scalar_types:
         - Title
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Album_update_column:
     representation:
       type: enum
@@ -27,6 +30,7 @@ scalar_types:
         - Title
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Artist_constraint:
     representation:
       type: enum
@@ -34,6 +38,7 @@ scalar_types:
         - PK_Artist
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Artist_select_column:
     representation:
       type: enum
@@ -42,6 +47,7 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Artist_update_column:
     representation:
       type: enum
@@ -49,9 +55,13 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Boolean:
+    representation:
+      type: boolean
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Customer_constraint:
     representation:
       type: enum
@@ -59,6 +69,7 @@ scalar_types:
         - PK_Customer
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Customer_select_column:
     representation:
       type: enum
@@ -78,6 +89,7 @@ scalar_types:
         - SupportRepId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Customer_update_column:
     representation:
       type: enum
@@ -96,6 +108,7 @@ scalar_types:
         - SupportRepId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Employee_constraint:
     representation:
       type: enum
@@ -103,6 +116,7 @@ scalar_types:
         - PK_Employee
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Employee_select_column:
     representation:
       type: enum
@@ -124,6 +138,7 @@ scalar_types:
         - Title
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Employee_update_column:
     representation:
       type: enum
@@ -144,9 +159,13 @@ scalar_types:
         - Title
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Float:
+    representation:
+      type: float64
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Genre_constraint:
     representation:
       type: enum
@@ -154,6 +173,7 @@ scalar_types:
         - PK_Genre
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Genre_select_column:
     representation:
       type: enum
@@ -162,6 +182,7 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Genre_update_column:
     representation:
       type: enum
@@ -169,9 +190,13 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Int:
+    representation:
+      type: int32
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   InvoiceLine_constraint:
     representation:
       type: enum
@@ -179,6 +204,7 @@ scalar_types:
         - PK_InvoiceLine
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   InvoiceLine_select_column:
     representation:
       type: enum
@@ -190,6 +216,7 @@ scalar_types:
         - UnitPrice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   InvoiceLine_update_column:
     representation:
       type: enum
@@ -200,6 +227,7 @@ scalar_types:
         - UnitPrice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Invoice_constraint:
     representation:
       type: enum
@@ -207,6 +235,7 @@ scalar_types:
         - PK_Invoice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Invoice_select_column:
     representation:
       type: enum
@@ -222,6 +251,7 @@ scalar_types:
         - Total
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Invoice_update_column:
     representation:
       type: enum
@@ -236,6 +266,7 @@ scalar_types:
         - Total
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   MediaType_constraint:
     representation:
       type: enum
@@ -243,6 +274,7 @@ scalar_types:
         - PK_MediaType
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   MediaType_select_column:
     representation:
       type: enum
@@ -251,6 +283,7 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   MediaType_update_column:
     representation:
       type: enum
@@ -258,6 +291,7 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   PlaylistTrack_constraint:
     representation:
       type: enum
@@ -265,6 +299,7 @@ scalar_types:
         - PK_PlaylistTrack
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   PlaylistTrack_select_column:
     representation:
       type: enum
@@ -273,6 +308,7 @@ scalar_types:
         - TrackId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   PlaylistTrack_update_column:
     representation:
       type: enum
@@ -281,6 +317,7 @@ scalar_types:
         - TrackId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Playlist_constraint:
     representation:
       type: enum
@@ -288,6 +325,7 @@ scalar_types:
         - PK_Playlist
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Playlist_select_column:
     representation:
       type: enum
@@ -296,6 +334,7 @@ scalar_types:
         - PlaylistId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Playlist_update_column:
     representation:
       type: enum
@@ -303,9 +342,13 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   String:
+    representation:
+      type: string
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Track_constraint:
     representation:
       type: enum
@@ -313,6 +356,7 @@ scalar_types:
         - PK_Track
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Track_select_column:
     representation:
       type: enum
@@ -328,6 +372,7 @@ scalar_types:
         - UnitPrice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Track_update_column:
     representation:
       type: enum
@@ -342,11 +387,13 @@ scalar_types:
         - UnitPrice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   _HeaderMap:
     representation:
       type: json
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   cursor_ordering:
     representation:
       type: enum
@@ -355,9 +402,13 @@ scalar_types:
         - DESC
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   numeric:
+    representation:
+      type: json
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   order_by:
     representation:
       type: enum
@@ -370,9 +421,13 @@ scalar_types:
         - desc_nulls_last
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   timestamp:
+    representation:
+      type: json
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
 object_types:
   Album:
     description: "columns and relationships of \"Album\""
@@ -486,6 +541,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Track_bool_exp
+    foreign_keys: {}
   Album_aggregate:
     description: "aggregated selection of \"Album\""
     fields:
@@ -501,6 +557,7 @@ object_types:
           element_type:
             type: named
             name: Album
+    foreign_keys: {}
   Album_aggregate_bool_exp:
     fields:
       count:
@@ -509,6 +566,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_aggregate_bool_exp_count
+    foreign_keys: {}
   Album_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -535,6 +593,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Album_aggregate_fields:
     description: "aggregate fields of \"Album\""
     fields:
@@ -617,6 +676,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_variance_fields
+    foreign_keys: {}
   Album_aggregate_order_by:
     description: "order by aggregate values of table \"Album\""
     fields:
@@ -686,6 +746,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_variance_order_by
+    foreign_keys: {}
   Album_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Album\""
     fields:
@@ -702,6 +763,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_on_conflict
+    foreign_keys: {}
   Album_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -717,6 +779,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_avg_order_by:
     description: "order by avg() on columns of table \"Album\""
     fields:
@@ -732,6 +795,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_bool_exp:
     description: "Boolean expression to filter rows from the table \"Album\". All fields are combined with a logical 'AND'."
     fields:
@@ -793,6 +857,7 @@ object_types:
             element_type:
               type: named
               name: Album_bool_exp
+    foreign_keys: {}
   Album_inc_input:
     description: "input type for incrementing numeric columns in table \"Album\""
     fields:
@@ -802,6 +867,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Album_insert_input:
     description: "input type for inserting data into table \"Album\""
     fields:
@@ -829,6 +895,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_arr_rel_insert_input
+    foreign_keys: {}
   Album_max_fields:
     description: aggregate max on columns
     fields:
@@ -850,6 +917,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Album_max_order_by:
     description: "order by max() on columns of table \"Album\""
     fields:
@@ -871,6 +939,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_min_fields:
     description: aggregate min on columns
     fields:
@@ -892,6 +961,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Album_min_order_by:
     description: "order by min() on columns of table \"Album\""
     fields:
@@ -913,6 +983,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_mutation_response:
     description: "response of any mutation on the table \"Album\""
     fields:
@@ -928,6 +999,7 @@ object_types:
           element_type:
             type: named
             name: Album
+    foreign_keys: {}
   Album_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Album\""
     fields:
@@ -942,6 +1014,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_on_conflict
+    foreign_keys: {}
   Album_on_conflict:
     description: "on_conflict condition type for table \"Album\""
     fields:
@@ -961,6 +1034,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_bool_exp
+    foreign_keys: {}
   Album_order_by:
     description: "Ordering options when selecting data from \"Album\"."
     fields:
@@ -994,6 +1068,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_aggregate_order_by
+    foreign_keys: {}
   Album_pk_columns_input:
     description: "primary key columns input for table: Album"
     fields:
@@ -1001,6 +1076,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Album_set_input:
     description: "input type for updating data in table \"Album\""
     fields:
@@ -1016,6 +1092,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Album_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -1031,6 +1108,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_stddev_order_by:
     description: "order by stddev() on columns of table \"Album\""
     fields:
@@ -1046,6 +1124,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -1061,6 +1140,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Album\""
     fields:
@@ -1076,6 +1156,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -1091,6 +1172,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Album\""
     fields:
@@ -1106,6 +1188,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_stream_cursor_input:
     description: "Streaming cursor of the table \"Album\""
     fields:
@@ -1121,6 +1204,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Album_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -1142,6 +1226,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Album_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -1157,6 +1242,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Album_sum_order_by:
     description: "order by sum() on columns of table \"Album\""
     fields:
@@ -1172,6 +1258,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_updates:
     fields:
       _inc:
@@ -1193,6 +1280,7 @@ object_types:
         type:
           type: named
           name: Album_bool_exp
+    foreign_keys: {}
   Album_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -1208,6 +1296,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Album\""
     fields:
@@ -1223,6 +1312,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -1238,6 +1328,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Album\""
     fields:
@@ -1253,6 +1344,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -1268,6 +1360,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_variance_order_by:
     description: "order by variance() on columns of table \"Album\""
     fields:
@@ -1283,6 +1376,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Artist:
     description: "columns and relationships of \"Artist\""
     fields:
@@ -1388,6 +1482,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_aggregate:
     description: "aggregated selection of \"Artist\""
     fields:
@@ -1403,6 +1498,7 @@ object_types:
           element_type:
             type: named
             name: Artist
+    foreign_keys: {}
   Artist_aggregate_fields:
     description: "aggregate fields of \"Artist\""
     fields:
@@ -1485,6 +1581,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_variance_fields
+    foreign_keys: {}
   Artist_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -1494,6 +1591,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_bool_exp:
     description: "Boolean expression to filter rows from the table \"Artist\". All fields are combined with a logical 'AND'."
     fields:
@@ -1543,6 +1641,7 @@ object_types:
             element_type:
               type: named
               name: Artist_bool_exp
+    foreign_keys: {}
   Artist_insert_input:
     description: "input type for inserting data into table \"Artist\""
     fields:
@@ -1558,6 +1657,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_max_fields:
     description: aggregate max on columns
     fields:
@@ -1573,6 +1673,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_min_fields:
     description: aggregate min on columns
     fields:
@@ -1588,6 +1689,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_mutation_response:
     description: "response of any mutation on the table \"Artist\""
     fields:
@@ -1603,6 +1705,7 @@ object_types:
           element_type:
             type: named
             name: Artist
+    foreign_keys: {}
   Artist_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Artist\""
     fields:
@@ -1617,6 +1720,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_on_conflict
+    foreign_keys: {}
   Artist_on_conflict:
     description: "on_conflict condition type for table \"Artist\""
     fields:
@@ -1636,6 +1740,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_bool_exp
+    foreign_keys: {}
   Artist_order_by:
     description: "Ordering options when selecting data from \"Artist\"."
     fields:
@@ -1657,6 +1762,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Artist_pk_columns_input:
     description: "primary key columns input for table: Artist"
     fields:
@@ -1664,6 +1770,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Artist_set_input:
     description: "input type for updating data in table \"Artist\""
     fields:
@@ -1673,6 +1780,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -1682,6 +1790,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -1691,6 +1800,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -1700,6 +1810,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_stream_cursor_input:
     description: "Streaming cursor of the table \"Artist\""
     fields:
@@ -1715,6 +1826,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Artist_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -1730,6 +1842,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -1739,6 +1852,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Artist_updates:
     fields:
       _set:
@@ -1753,6 +1867,7 @@ object_types:
         type:
           type: named
           name: Artist_bool_exp
+    foreign_keys: {}
   Artist_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -1762,6 +1877,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -1771,6 +1887,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -1780,6 +1897,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer:
     description: "columns and relationships of \"Customer\""
     fields:
@@ -1952,6 +2070,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_aggregate:
     description: "aggregated selection of \"Customer\""
     fields:
@@ -1967,6 +2086,7 @@ object_types:
           element_type:
             type: named
             name: Customer
+    foreign_keys: {}
   Customer_aggregate_bool_exp:
     fields:
       count:
@@ -1975,6 +2095,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_aggregate_bool_exp_count
+    foreign_keys: {}
   Customer_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -2001,6 +2122,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Customer_aggregate_fields:
     description: "aggregate fields of \"Customer\""
     fields:
@@ -2083,6 +2205,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_variance_fields
+    foreign_keys: {}
   Customer_aggregate_order_by:
     description: "order by aggregate values of table \"Customer\""
     fields:
@@ -2152,6 +2275,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_variance_order_by
+    foreign_keys: {}
   Customer_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Customer\""
     fields:
@@ -2168,6 +2292,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_on_conflict
+    foreign_keys: {}
   Customer_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -2183,6 +2308,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_avg_order_by:
     description: "order by avg() on columns of table \"Customer\""
     fields:
@@ -2198,6 +2324,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_bool_exp:
     description: "Boolean expression to filter rows from the table \"Customer\". All fields are combined with a logical 'AND'."
     fields:
@@ -2319,6 +2446,7 @@ object_types:
             element_type:
               type: named
               name: Customer_bool_exp
+    foreign_keys: {}
   Customer_inc_input:
     description: "input type for incrementing numeric columns in table \"Customer\""
     fields:
@@ -2328,6 +2456,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_insert_input:
     description: "input type for inserting data into table \"Customer\""
     fields:
@@ -2415,6 +2544,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_max_fields:
     description: aggregate max on columns
     fields:
@@ -2496,6 +2626,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_max_order_by:
     description: "order by max() on columns of table \"Customer\""
     fields:
@@ -2577,6 +2708,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_min_fields:
     description: aggregate min on columns
     fields:
@@ -2658,6 +2790,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_min_order_by:
     description: "order by min() on columns of table \"Customer\""
     fields:
@@ -2739,6 +2872,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_mutation_response:
     description: "response of any mutation on the table \"Customer\""
     fields:
@@ -2754,6 +2888,7 @@ object_types:
           element_type:
             type: named
             name: Customer
+    foreign_keys: {}
   Customer_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Customer\""
     fields:
@@ -2768,6 +2903,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_on_conflict
+    foreign_keys: {}
   Customer_on_conflict:
     description: "on_conflict condition type for table \"Customer\""
     fields:
@@ -2787,6 +2923,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_bool_exp
+    foreign_keys: {}
   Customer_order_by:
     description: "Ordering options when selecting data from \"Customer\"."
     fields:
@@ -2880,6 +3017,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_pk_columns_input:
     description: "primary key columns input for table: Customer"
     fields:
@@ -2887,6 +3025,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Customer_set_input:
     description: "input type for updating data in table \"Customer\""
     fields:
@@ -2962,6 +3101,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -2977,6 +3117,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_stddev_order_by:
     description: "order by stddev() on columns of table \"Customer\""
     fields:
@@ -2992,6 +3133,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -3007,6 +3149,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Customer\""
     fields:
@@ -3022,6 +3165,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -3037,6 +3181,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Customer\""
     fields:
@@ -3052,6 +3197,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_stream_cursor_input:
     description: "Streaming cursor of the table \"Customer\""
     fields:
@@ -3067,6 +3213,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Customer_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -3148,6 +3295,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -3163,6 +3311,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_sum_order_by:
     description: "order by sum() on columns of table \"Customer\""
     fields:
@@ -3178,6 +3327,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_updates:
     fields:
       _inc:
@@ -3199,6 +3349,7 @@ object_types:
         type:
           type: named
           name: Customer_bool_exp
+    foreign_keys: {}
   Customer_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -3214,6 +3365,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Customer\""
     fields:
@@ -3229,6 +3381,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -3244,6 +3397,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Customer\""
     fields:
@@ -3259,6 +3413,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -3274,6 +3429,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_variance_order_by:
     description: "order by variance() on columns of table \"Customer\""
     fields:
@@ -3289,6 +3445,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee:
     description: "columns and relationships of \"Employee\""
     fields:
@@ -3567,6 +3724,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_aggregate:
     description: "aggregated selection of \"Employee\""
     fields:
@@ -3582,6 +3740,7 @@ object_types:
           element_type:
             type: named
             name: Employee
+    foreign_keys: {}
   Employee_aggregate_bool_exp:
     fields:
       count:
@@ -3590,6 +3749,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_aggregate_bool_exp_count
+    foreign_keys: {}
   Employee_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -3616,6 +3776,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Employee_aggregate_fields:
     description: "aggregate fields of \"Employee\""
     fields:
@@ -3698,6 +3859,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_variance_fields
+    foreign_keys: {}
   Employee_aggregate_order_by:
     description: "order by aggregate values of table \"Employee\""
     fields:
@@ -3767,6 +3929,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_variance_order_by
+    foreign_keys: {}
   Employee_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Employee\""
     fields:
@@ -3783,6 +3946,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_on_conflict
+    foreign_keys: {}
   Employee_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -3798,6 +3962,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_avg_order_by:
     description: "order by avg() on columns of table \"Employee\""
     fields:
@@ -3813,6 +3978,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_bool_exp:
     description: "Boolean expression to filter rows from the table \"Employee\". All fields are combined with a logical 'AND'."
     fields:
@@ -3958,6 +4124,7 @@ object_types:
             element_type:
               type: named
               name: Employee_bool_exp
+    foreign_keys: {}
   Employee_inc_input:
     description: "input type for incrementing numeric columns in table \"Employee\""
     fields:
@@ -3967,6 +4134,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Employee_insert_input:
     description: "input type for inserting data into table \"Employee\""
     fields:
@@ -4072,6 +4240,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_max_fields:
     description: aggregate max on columns
     fields:
@@ -4165,6 +4334,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_max_order_by:
     description: "order by max() on columns of table \"Employee\""
     fields:
@@ -4258,6 +4428,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_min_fields:
     description: aggregate min on columns
     fields:
@@ -4351,6 +4522,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_min_order_by:
     description: "order by min() on columns of table \"Employee\""
     fields:
@@ -4444,6 +4616,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_mutation_response:
     description: "response of any mutation on the table \"Employee\""
     fields:
@@ -4459,6 +4632,7 @@ object_types:
           element_type:
             type: named
             name: Employee
+    foreign_keys: {}
   Employee_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Employee\""
     fields:
@@ -4473,6 +4647,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_on_conflict
+    foreign_keys: {}
   Employee_on_conflict:
     description: "on_conflict condition type for table \"Employee\""
     fields:
@@ -4492,6 +4667,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_bool_exp
+    foreign_keys: {}
   Employee_order_by:
     description: "Ordering options when selecting data from \"Employee\"."
     fields:
@@ -4603,6 +4779,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_pk_columns_input:
     description: "primary key columns input for table: Employee"
     fields:
@@ -4610,6 +4787,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Employee_set_input:
     description: "input type for updating data in table \"Employee\""
     fields:
@@ -4697,6 +4875,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -4712,6 +4891,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_stddev_order_by:
     description: "order by stddev() on columns of table \"Employee\""
     fields:
@@ -4727,6 +4907,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -4742,6 +4923,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Employee\""
     fields:
@@ -4757,6 +4939,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -4772,6 +4955,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Employee\""
     fields:
@@ -4787,6 +4971,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_stream_cursor_input:
     description: "Streaming cursor of the table \"Employee\""
     fields:
@@ -4802,6 +4987,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Employee_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -4895,6 +5081,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -4910,6 +5097,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Employee_sum_order_by:
     description: "order by sum() on columns of table \"Employee\""
     fields:
@@ -4925,6 +5113,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_updates:
     fields:
       _inc:
@@ -4946,6 +5135,7 @@ object_types:
         type:
           type: named
           name: Employee_bool_exp
+    foreign_keys: {}
   Employee_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -4961,6 +5151,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Employee\""
     fields:
@@ -4976,6 +5167,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -4991,6 +5183,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Employee\""
     fields:
@@ -5006,6 +5199,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -5021,6 +5215,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_variance_order_by:
     description: "order by variance() on columns of table \"Employee\""
     fields:
@@ -5036,6 +5231,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Genre:
     description: "columns and relationships of \"Genre\""
     fields:
@@ -5141,6 +5337,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Track_bool_exp
+    foreign_keys: {}
   Genre_aggregate:
     description: "aggregated selection of \"Genre\""
     fields:
@@ -5156,6 +5353,7 @@ object_types:
           element_type:
             type: named
             name: Genre
+    foreign_keys: {}
   Genre_aggregate_fields:
     description: "aggregate fields of \"Genre\""
     fields:
@@ -5238,6 +5436,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_variance_fields
+    foreign_keys: {}
   Genre_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -5247,6 +5446,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_bool_exp:
     description: "Boolean expression to filter rows from the table \"Genre\". All fields are combined with a logical 'AND'."
     fields:
@@ -5296,6 +5496,7 @@ object_types:
             element_type:
               type: named
               name: Genre_bool_exp
+    foreign_keys: {}
   Genre_insert_input:
     description: "input type for inserting data into table \"Genre\""
     fields:
@@ -5311,6 +5512,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_arr_rel_insert_input
+    foreign_keys: {}
   Genre_max_fields:
     description: aggregate max on columns
     fields:
@@ -5326,6 +5528,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Genre_min_fields:
     description: aggregate min on columns
     fields:
@@ -5341,6 +5544,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Genre_mutation_response:
     description: "response of any mutation on the table \"Genre\""
     fields:
@@ -5356,6 +5560,7 @@ object_types:
           element_type:
             type: named
             name: Genre
+    foreign_keys: {}
   Genre_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Genre\""
     fields:
@@ -5370,6 +5575,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_on_conflict
+    foreign_keys: {}
   Genre_on_conflict:
     description: "on_conflict condition type for table \"Genre\""
     fields:
@@ -5389,6 +5595,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_bool_exp
+    foreign_keys: {}
   Genre_order_by:
     description: "Ordering options when selecting data from \"Genre\"."
     fields:
@@ -5410,6 +5617,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_aggregate_order_by
+    foreign_keys: {}
   Genre_pk_columns_input:
     description: "primary key columns input for table: Genre"
     fields:
@@ -5417,6 +5625,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Genre_set_input:
     description: "input type for updating data in table \"Genre\""
     fields:
@@ -5426,6 +5635,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Genre_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -5435,6 +5645,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -5444,6 +5655,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -5453,6 +5665,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_stream_cursor_input:
     description: "Streaming cursor of the table \"Genre\""
     fields:
@@ -5468,6 +5681,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Genre_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -5483,6 +5697,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Genre_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -5492,6 +5707,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Genre_updates:
     fields:
       _set:
@@ -5506,6 +5722,7 @@ object_types:
         type:
           type: named
           name: Genre_bool_exp
+    foreign_keys: {}
   Genre_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -5515,6 +5732,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -5524,6 +5742,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -5533,6 +5752,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Int_comparison_exp:
     description: "Boolean expression to compare columns of type \"Int\". All fields are combined with logical 'AND'."
     fields:
@@ -5594,6 +5814,7 @@ object_types:
             element_type:
               type: named
               name: Int
+    foreign_keys: {}
   Invoice:
     description: "columns and relationships of \"Invoice\""
     fields:
@@ -5740,6 +5961,7 @@ object_types:
         type:
           type: named
           name: numeric
+    foreign_keys: {}
   InvoiceLine:
     description: "columns and relationships of \"InvoiceLine\""
     fields:
@@ -5773,6 +5995,7 @@ object_types:
         type:
           type: named
           name: numeric
+    foreign_keys: {}
   InvoiceLine_aggregate:
     description: "aggregated selection of \"InvoiceLine\""
     fields:
@@ -5788,6 +6011,7 @@ object_types:
           element_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   InvoiceLine_aggregate_bool_exp:
     fields:
       count:
@@ -5796,6 +6020,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_aggregate_bool_exp_count
+    foreign_keys: {}
   InvoiceLine_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -5822,6 +6047,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   InvoiceLine_aggregate_fields:
     description: "aggregate fields of \"InvoiceLine\""
     fields:
@@ -5904,6 +6130,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_variance_fields
+    foreign_keys: {}
   InvoiceLine_aggregate_order_by:
     description: "order by aggregate values of table \"InvoiceLine\""
     fields:
@@ -5973,6 +6200,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_variance_order_by
+    foreign_keys: {}
   InvoiceLine_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"InvoiceLine\""
     fields:
@@ -5989,6 +6217,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_on_conflict
+    foreign_keys: {}
   InvoiceLine_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -6022,6 +6251,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_avg_order_by:
     description: "order by avg() on columns of table \"InvoiceLine\""
     fields:
@@ -6055,6 +6285,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_bool_exp:
     description: "Boolean expression to filter rows from the table \"InvoiceLine\". All fields are combined with a logical 'AND'."
     fields:
@@ -6122,6 +6353,7 @@ object_types:
             element_type:
               type: named
               name: InvoiceLine_bool_exp
+    foreign_keys: {}
   InvoiceLine_inc_input:
     description: "input type for incrementing numeric columns in table \"InvoiceLine\""
     fields:
@@ -6149,6 +6381,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_insert_input:
     description: "input type for inserting data into table \"InvoiceLine\""
     fields:
@@ -6188,6 +6421,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_max_fields:
     description: aggregate max on columns
     fields:
@@ -6221,6 +6455,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_max_order_by:
     description: "order by max() on columns of table \"InvoiceLine\""
     fields:
@@ -6254,6 +6489,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_min_fields:
     description: aggregate min on columns
     fields:
@@ -6287,6 +6523,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_min_order_by:
     description: "order by min() on columns of table \"InvoiceLine\""
     fields:
@@ -6320,6 +6557,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_mutation_response:
     description: "response of any mutation on the table \"InvoiceLine\""
     fields:
@@ -6335,6 +6573,7 @@ object_types:
           element_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   InvoiceLine_on_conflict:
     description: "on_conflict condition type for table \"InvoiceLine\""
     fields:
@@ -6354,6 +6593,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_bool_exp
+    foreign_keys: {}
   InvoiceLine_order_by:
     description: "Ordering options when selecting data from \"InvoiceLine\"."
     fields:
@@ -6399,6 +6639,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_pk_columns_input:
     description: "primary key columns input for table: InvoiceLine"
     fields:
@@ -6406,6 +6647,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   InvoiceLine_set_input:
     description: "input type for updating data in table \"InvoiceLine\""
     fields:
@@ -6433,6 +6675,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -6466,6 +6709,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_stddev_order_by:
     description: "order by stddev() on columns of table \"InvoiceLine\""
     fields:
@@ -6499,6 +6743,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -6532,6 +6777,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"InvoiceLine\""
     fields:
@@ -6565,6 +6811,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -6598,6 +6845,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"InvoiceLine\""
     fields:
@@ -6631,6 +6879,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_stream_cursor_input:
     description: "Streaming cursor of the table \"InvoiceLine\""
     fields:
@@ -6646,6 +6895,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   InvoiceLine_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -6679,6 +6929,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -6712,6 +6963,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_sum_order_by:
     description: "order by sum() on columns of table \"InvoiceLine\""
     fields:
@@ -6745,6 +6997,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_updates:
     fields:
       _inc:
@@ -6766,6 +7019,7 @@ object_types:
         type:
           type: named
           name: InvoiceLine_bool_exp
+    foreign_keys: {}
   InvoiceLine_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -6799,6 +7053,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_var_pop_order_by:
     description: "order by var_pop() on columns of table \"InvoiceLine\""
     fields:
@@ -6832,6 +7087,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -6865,6 +7121,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_var_samp_order_by:
     description: "order by var_samp() on columns of table \"InvoiceLine\""
     fields:
@@ -6898,6 +7155,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -6931,6 +7189,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_variance_order_by:
     description: "order by variance() on columns of table \"InvoiceLine\""
     fields:
@@ -6964,6 +7223,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_aggregate:
     description: "aggregated selection of \"Invoice\""
     fields:
@@ -6979,6 +7239,7 @@ object_types:
           element_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   Invoice_aggregate_bool_exp:
     fields:
       count:
@@ -6987,6 +7248,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_aggregate_bool_exp_count
+    foreign_keys: {}
   Invoice_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -7013,6 +7275,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Invoice_aggregate_fields:
     description: "aggregate fields of \"Invoice\""
     fields:
@@ -7095,6 +7358,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_variance_fields
+    foreign_keys: {}
   Invoice_aggregate_order_by:
     description: "order by aggregate values of table \"Invoice\""
     fields:
@@ -7164,6 +7428,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_variance_order_by
+    foreign_keys: {}
   Invoice_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Invoice\""
     fields:
@@ -7180,6 +7445,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_on_conflict
+    foreign_keys: {}
   Invoice_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -7201,6 +7467,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_avg_order_by:
     description: "order by avg() on columns of table \"Invoice\""
     fields:
@@ -7222,6 +7489,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_bool_exp:
     description: "Boolean expression to filter rows from the table \"Invoice\". All fields are combined with a logical 'AND'."
     fields:
@@ -7319,6 +7587,7 @@ object_types:
             element_type:
               type: named
               name: Invoice_bool_exp
+    foreign_keys: {}
   Invoice_inc_input:
     description: "input type for incrementing numeric columns in table \"Invoice\""
     fields:
@@ -7334,6 +7603,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_insert_input:
     description: "input type for inserting data into table \"Invoice\""
     fields:
@@ -7397,6 +7667,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_max_fields:
     description: aggregate max on columns
     fields:
@@ -7454,6 +7725,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_max_order_by:
     description: "order by max() on columns of table \"Invoice\""
     fields:
@@ -7511,6 +7783,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_min_fields:
     description: aggregate min on columns
     fields:
@@ -7568,6 +7841,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_min_order_by:
     description: "order by min() on columns of table \"Invoice\""
     fields:
@@ -7625,6 +7899,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_mutation_response:
     description: "response of any mutation on the table \"Invoice\""
     fields:
@@ -7640,6 +7915,7 @@ object_types:
           element_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   Invoice_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Invoice\""
     fields:
@@ -7654,6 +7930,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_on_conflict
+    foreign_keys: {}
   Invoice_on_conflict:
     description: "on_conflict condition type for table \"Invoice\""
     fields:
@@ -7673,6 +7950,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_bool_exp
+    foreign_keys: {}
   Invoice_order_by:
     description: "Ordering options when selecting data from \"Invoice\"."
     fields:
@@ -7742,6 +8020,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_pk_columns_input:
     description: "primary key columns input for table: Invoice"
     fields:
@@ -7749,6 +8028,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Invoice_set_input:
     description: "input type for updating data in table \"Invoice\""
     fields:
@@ -7800,6 +8080,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -7821,6 +8102,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_stddev_order_by:
     description: "order by stddev() on columns of table \"Invoice\""
     fields:
@@ -7842,6 +8124,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -7863,6 +8146,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Invoice\""
     fields:
@@ -7884,6 +8168,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -7905,6 +8190,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Invoice\""
     fields:
@@ -7926,6 +8212,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_stream_cursor_input:
     description: "Streaming cursor of the table \"Invoice\""
     fields:
@@ -7941,6 +8228,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Invoice_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -7998,6 +8286,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -8019,6 +8308,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_sum_order_by:
     description: "order by sum() on columns of table \"Invoice\""
     fields:
@@ -8040,6 +8330,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_updates:
     fields:
       _inc:
@@ -8061,6 +8352,7 @@ object_types:
         type:
           type: named
           name: Invoice_bool_exp
+    foreign_keys: {}
   Invoice_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -8082,6 +8374,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Invoice\""
     fields:
@@ -8103,6 +8396,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -8124,6 +8418,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Invoice\""
     fields:
@@ -8145,6 +8440,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -8166,6 +8462,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_variance_order_by:
     description: "order by variance() on columns of table \"Invoice\""
     fields:
@@ -8187,6 +8484,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   MediaType:
     description: "columns and relationships of \"MediaType\""
     fields:
@@ -8292,6 +8590,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Track_bool_exp
+    foreign_keys: {}
   MediaType_aggregate:
     description: "aggregated selection of \"MediaType\""
     fields:
@@ -8307,6 +8606,7 @@ object_types:
           element_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   MediaType_aggregate_fields:
     description: "aggregate fields of \"MediaType\""
     fields:
@@ -8389,6 +8689,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_variance_fields
+    foreign_keys: {}
   MediaType_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -8398,6 +8699,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_bool_exp:
     description: "Boolean expression to filter rows from the table \"MediaType\". All fields are combined with a logical 'AND'."
     fields:
@@ -8447,6 +8749,7 @@ object_types:
             element_type:
               type: named
               name: MediaType_bool_exp
+    foreign_keys: {}
   MediaType_insert_input:
     description: "input type for inserting data into table \"MediaType\""
     fields:
@@ -8462,6 +8765,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_arr_rel_insert_input
+    foreign_keys: {}
   MediaType_max_fields:
     description: aggregate max on columns
     fields:
@@ -8477,6 +8781,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   MediaType_min_fields:
     description: aggregate min on columns
     fields:
@@ -8492,6 +8797,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   MediaType_mutation_response:
     description: "response of any mutation on the table \"MediaType\""
     fields:
@@ -8507,6 +8813,7 @@ object_types:
           element_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   MediaType_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"MediaType\""
     fields:
@@ -8521,6 +8828,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_on_conflict
+    foreign_keys: {}
   MediaType_on_conflict:
     description: "on_conflict condition type for table \"MediaType\""
     fields:
@@ -8540,6 +8848,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_bool_exp
+    foreign_keys: {}
   MediaType_order_by:
     description: "Ordering options when selecting data from \"MediaType\"."
     fields:
@@ -8561,6 +8870,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_aggregate_order_by
+    foreign_keys: {}
   MediaType_pk_columns_input:
     description: "primary key columns input for table: MediaType"
     fields:
@@ -8568,6 +8878,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   MediaType_set_input:
     description: "input type for updating data in table \"MediaType\""
     fields:
@@ -8577,6 +8888,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   MediaType_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -8586,6 +8898,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -8595,6 +8908,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -8604,6 +8918,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_stream_cursor_input:
     description: "Streaming cursor of the table \"MediaType\""
     fields:
@@ -8619,6 +8934,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   MediaType_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -8634,6 +8950,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   MediaType_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -8643,6 +8960,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   MediaType_updates:
     fields:
       _set:
@@ -8657,6 +8975,7 @@ object_types:
         type:
           type: named
           name: MediaType_bool_exp
+    foreign_keys: {}
   MediaType_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -8666,6 +8985,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -8675,6 +8995,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -8684,6 +9005,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist:
     description: "columns and relationships of \"Playlist\""
     fields:
@@ -8789,6 +9111,7 @@ object_types:
               underlying_type:
                 type: named
                 name: PlaylistTrack_bool_exp
+    foreign_keys: {}
   PlaylistTrack:
     description: "columns and relationships of \"PlaylistTrack\""
     fields:
@@ -8810,6 +9133,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   PlaylistTrack_aggregate:
     description: "aggregated selection of \"PlaylistTrack\""
     fields:
@@ -8825,6 +9149,7 @@ object_types:
           element_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   PlaylistTrack_aggregate_bool_exp:
     fields:
       count:
@@ -8833,6 +9158,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_aggregate_bool_exp_count
+    foreign_keys: {}
   PlaylistTrack_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -8859,6 +9185,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   PlaylistTrack_aggregate_fields:
     description: "aggregate fields of \"PlaylistTrack\""
     fields:
@@ -8941,6 +9268,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_variance_fields
+    foreign_keys: {}
   PlaylistTrack_aggregate_order_by:
     description: "order by aggregate values of table \"PlaylistTrack\""
     fields:
@@ -9010,6 +9338,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_variance_order_by
+    foreign_keys: {}
   PlaylistTrack_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"PlaylistTrack\""
     fields:
@@ -9026,6 +9355,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_on_conflict
+    foreign_keys: {}
   PlaylistTrack_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -9041,6 +9371,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_avg_order_by:
     description: "order by avg() on columns of table \"PlaylistTrack\""
     fields:
@@ -9056,6 +9387,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_bool_exp:
     description: "Boolean expression to filter rows from the table \"PlaylistTrack\". All fields are combined with a logical 'AND'."
     fields:
@@ -9105,6 +9437,7 @@ object_types:
             element_type:
               type: named
               name: PlaylistTrack_bool_exp
+    foreign_keys: {}
   PlaylistTrack_inc_input:
     description: "input type for incrementing numeric columns in table \"PlaylistTrack\""
     fields:
@@ -9120,6 +9453,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_insert_input:
     description: "input type for inserting data into table \"PlaylistTrack\""
     fields:
@@ -9147,6 +9481,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_max_fields:
     description: aggregate max on columns
     fields:
@@ -9162,6 +9497,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_max_order_by:
     description: "order by max() on columns of table \"PlaylistTrack\""
     fields:
@@ -9177,6 +9513,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_min_fields:
     description: aggregate min on columns
     fields:
@@ -9192,6 +9529,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_min_order_by:
     description: "order by min() on columns of table \"PlaylistTrack\""
     fields:
@@ -9207,6 +9545,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_mutation_response:
     description: "response of any mutation on the table \"PlaylistTrack\""
     fields:
@@ -9222,6 +9561,7 @@ object_types:
           element_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   PlaylistTrack_on_conflict:
     description: "on_conflict condition type for table \"PlaylistTrack\""
     fields:
@@ -9241,6 +9581,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_bool_exp
+    foreign_keys: {}
   PlaylistTrack_order_by:
     description: "Ordering options when selecting data from \"PlaylistTrack\"."
     fields:
@@ -9268,6 +9609,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_pk_columns_input:
     description: "primary key columns input for table: PlaylistTrack"
     fields:
@@ -9279,6 +9621,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   PlaylistTrack_set_input:
     description: "input type for updating data in table \"PlaylistTrack\""
     fields:
@@ -9294,6 +9637,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -9309,6 +9653,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_stddev_order_by:
     description: "order by stddev() on columns of table \"PlaylistTrack\""
     fields:
@@ -9324,6 +9669,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -9339,6 +9685,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"PlaylistTrack\""
     fields:
@@ -9354,6 +9701,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -9369,6 +9717,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"PlaylistTrack\""
     fields:
@@ -9384,6 +9733,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_stream_cursor_input:
     description: "Streaming cursor of the table \"PlaylistTrack\""
     fields:
@@ -9399,6 +9749,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   PlaylistTrack_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -9414,6 +9765,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -9429,6 +9781,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_sum_order_by:
     description: "order by sum() on columns of table \"PlaylistTrack\""
     fields:
@@ -9444,6 +9797,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_updates:
     fields:
       _inc:
@@ -9465,6 +9819,7 @@ object_types:
         type:
           type: named
           name: PlaylistTrack_bool_exp
+    foreign_keys: {}
   PlaylistTrack_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -9480,6 +9835,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_var_pop_order_by:
     description: "order by var_pop() on columns of table \"PlaylistTrack\""
     fields:
@@ -9495,6 +9851,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -9510,6 +9867,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_var_samp_order_by:
     description: "order by var_samp() on columns of table \"PlaylistTrack\""
     fields:
@@ -9525,6 +9883,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -9540,6 +9899,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_variance_order_by:
     description: "order by variance() on columns of table \"PlaylistTrack\""
     fields:
@@ -9555,6 +9915,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Playlist_aggregate:
     description: "aggregated selection of \"Playlist\""
     fields:
@@ -9570,6 +9931,7 @@ object_types:
           element_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   Playlist_aggregate_fields:
     description: "aggregate fields of \"Playlist\""
     fields:
@@ -9652,6 +10014,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_variance_fields
+    foreign_keys: {}
   Playlist_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -9661,6 +10024,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_bool_exp:
     description: "Boolean expression to filter rows from the table \"Playlist\". All fields are combined with a logical 'AND'."
     fields:
@@ -9710,6 +10074,7 @@ object_types:
             element_type:
               type: named
               name: Playlist_bool_exp
+    foreign_keys: {}
   Playlist_insert_input:
     description: "input type for inserting data into table \"Playlist\""
     fields:
@@ -9725,6 +10090,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_arr_rel_insert_input
+    foreign_keys: {}
   Playlist_max_fields:
     description: aggregate max on columns
     fields:
@@ -9740,6 +10106,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Playlist_min_fields:
     description: aggregate min on columns
     fields:
@@ -9755,6 +10122,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Playlist_mutation_response:
     description: "response of any mutation on the table \"Playlist\""
     fields:
@@ -9770,6 +10138,7 @@ object_types:
           element_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   Playlist_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Playlist\""
     fields:
@@ -9784,6 +10153,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_on_conflict
+    foreign_keys: {}
   Playlist_on_conflict:
     description: "on_conflict condition type for table \"Playlist\""
     fields:
@@ -9803,6 +10173,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_bool_exp
+    foreign_keys: {}
   Playlist_order_by:
     description: "Ordering options when selecting data from \"Playlist\"."
     fields:
@@ -9824,6 +10195,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_aggregate_order_by
+    foreign_keys: {}
   Playlist_pk_columns_input:
     description: "primary key columns input for table: Playlist"
     fields:
@@ -9831,6 +10203,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Playlist_set_input:
     description: "input type for updating data in table \"Playlist\""
     fields:
@@ -9840,6 +10213,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Playlist_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -9849,6 +10223,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -9858,6 +10233,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -9867,6 +10243,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_stream_cursor_input:
     description: "Streaming cursor of the table \"Playlist\""
     fields:
@@ -9882,6 +10259,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Playlist_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -9897,6 +10275,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Playlist_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -9906,6 +10285,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Playlist_updates:
     fields:
       _set:
@@ -9920,6 +10300,7 @@ object_types:
         type:
           type: named
           name: Playlist_bool_exp
+    foreign_keys: {}
   Playlist_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -9929,6 +10310,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -9938,6 +10320,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -9947,6 +10330,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   String_comparison_exp:
     description: "Boolean expression to compare columns of type \"String\". All fields are combined with logical 'AND'."
     fields:
@@ -10078,6 +10462,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Track:
     description: "columns and relationships of \"Track\""
     fields:
@@ -10328,6 +10713,7 @@ object_types:
         type:
           type: named
           name: numeric
+    foreign_keys: {}
   Track_aggregate:
     description: "aggregated selection of \"Track\""
     fields:
@@ -10343,6 +10729,7 @@ object_types:
           element_type:
             type: named
             name: Track
+    foreign_keys: {}
   Track_aggregate_bool_exp:
     fields:
       count:
@@ -10351,6 +10738,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_aggregate_bool_exp_count
+    foreign_keys: {}
   Track_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -10377,6 +10765,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Track_aggregate_fields:
     description: "aggregate fields of \"Track\""
     fields:
@@ -10459,6 +10848,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_variance_fields
+    foreign_keys: {}
   Track_aggregate_order_by:
     description: "order by aggregate values of table \"Track\""
     fields:
@@ -10528,6 +10918,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_variance_order_by
+    foreign_keys: {}
   Track_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Track\""
     fields:
@@ -10544,6 +10935,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_on_conflict
+    foreign_keys: {}
   Track_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -10589,6 +10981,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_avg_order_by:
     description: "order by avg() on columns of table \"Track\""
     fields:
@@ -10634,6 +11027,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_bool_exp:
     description: "Boolean expression to filter rows from the table \"Track\". All fields are combined with a logical 'AND'."
     fields:
@@ -10755,6 +11149,7 @@ object_types:
             element_type:
               type: named
               name: Track_bool_exp
+    foreign_keys: {}
   Track_inc_input:
     description: "input type for incrementing numeric columns in table \"Track\""
     fields:
@@ -10794,6 +11189,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_insert_input:
     description: "input type for inserting data into table \"Track\""
     fields:
@@ -10875,6 +11271,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_max_fields:
     description: aggregate max on columns
     fields:
@@ -10932,6 +11329,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_max_order_by:
     description: "order by max() on columns of table \"Track\""
     fields:
@@ -10989,6 +11387,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_min_fields:
     description: aggregate min on columns
     fields:
@@ -11046,6 +11445,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_min_order_by:
     description: "order by min() on columns of table \"Track\""
     fields:
@@ -11103,6 +11503,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_mutation_response:
     description: "response of any mutation on the table \"Track\""
     fields:
@@ -11118,6 +11519,7 @@ object_types:
           element_type:
             type: named
             name: Track
+    foreign_keys: {}
   Track_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Track\""
     fields:
@@ -11132,6 +11534,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_on_conflict
+    foreign_keys: {}
   Track_on_conflict:
     description: "on_conflict condition type for table \"Track\""
     fields:
@@ -11151,6 +11554,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_bool_exp
+    foreign_keys: {}
   Track_order_by:
     description: "Ordering options when selecting data from \"Track\"."
     fields:
@@ -11238,6 +11642,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_pk_columns_input:
     description: "primary key columns input for table: Track"
     fields:
@@ -11245,6 +11650,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Track_set_input:
     description: "input type for updating data in table \"Track\""
     fields:
@@ -11296,6 +11702,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -11341,6 +11748,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_stddev_order_by:
     description: "order by stddev() on columns of table \"Track\""
     fields:
@@ -11386,6 +11794,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -11431,6 +11840,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Track\""
     fields:
@@ -11476,6 +11886,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -11521,6 +11932,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Track\""
     fields:
@@ -11566,6 +11978,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_stream_cursor_input:
     description: "Streaming cursor of the table \"Track\""
     fields:
@@ -11581,6 +11994,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Track_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -11638,6 +12052,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -11683,6 +12098,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_sum_order_by:
     description: "order by sum() on columns of table \"Track\""
     fields:
@@ -11728,6 +12144,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_updates:
     fields:
       _inc:
@@ -11749,6 +12166,7 @@ object_types:
         type:
           type: named
           name: Track_bool_exp
+    foreign_keys: {}
   Track_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -11794,6 +12212,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Track\""
     fields:
@@ -11839,6 +12258,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -11884,6 +12304,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Track\""
     fields:
@@ -11929,6 +12350,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -11974,6 +12396,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_variance_order_by:
     description: "order by variance() on columns of table \"Track\""
     fields:
@@ -12019,6 +12442,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   _AlbumQueryResponse:
     description: Response type for function Album
     fields:
@@ -12032,6 +12456,7 @@ object_types:
           element_type:
             type: named
             name: Album
+    foreign_keys: {}
   _Album_aggregateQueryResponse:
     description: Response type for function Album_aggregate
     fields:
@@ -12043,6 +12468,7 @@ object_types:
         type:
           type: named
           name: Album_aggregate
+    foreign_keys: {}
   _Album_by_pkQueryResponse:
     description: Response type for function Album_by_pk
     fields:
@@ -12056,6 +12482,7 @@ object_types:
           underlying_type:
             type: named
             name: Album
+    foreign_keys: {}
   _ArtistQueryResponse:
     description: Response type for function Artist
     fields:
@@ -12069,6 +12496,7 @@ object_types:
           element_type:
             type: named
             name: Artist
+    foreign_keys: {}
   _Artist_aggregateQueryResponse:
     description: Response type for function Artist_aggregate
     fields:
@@ -12080,6 +12508,7 @@ object_types:
         type:
           type: named
           name: Artist_aggregate
+    foreign_keys: {}
   _Artist_by_pkQueryResponse:
     description: Response type for function Artist_by_pk
     fields:
@@ -12093,6 +12522,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist
+    foreign_keys: {}
   _CustomerQueryResponse:
     description: Response type for function Customer
     fields:
@@ -12106,6 +12536,7 @@ object_types:
           element_type:
             type: named
             name: Customer
+    foreign_keys: {}
   _Customer_aggregateQueryResponse:
     description: Response type for function Customer_aggregate
     fields:
@@ -12117,6 +12548,7 @@ object_types:
         type:
           type: named
           name: Customer_aggregate
+    foreign_keys: {}
   _Customer_by_pkQueryResponse:
     description: Response type for function Customer_by_pk
     fields:
@@ -12130,6 +12562,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer
+    foreign_keys: {}
   _EmployeeQueryResponse:
     description: Response type for function Employee
     fields:
@@ -12143,6 +12576,7 @@ object_types:
           element_type:
             type: named
             name: Employee
+    foreign_keys: {}
   _Employee_aggregateQueryResponse:
     description: Response type for function Employee_aggregate
     fields:
@@ -12154,6 +12588,7 @@ object_types:
         type:
           type: named
           name: Employee_aggregate
+    foreign_keys: {}
   _Employee_by_pkQueryResponse:
     description: Response type for function Employee_by_pk
     fields:
@@ -12167,6 +12602,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee
+    foreign_keys: {}
   _GenreQueryResponse:
     description: Response type for function Genre
     fields:
@@ -12180,6 +12616,7 @@ object_types:
           element_type:
             type: named
             name: Genre
+    foreign_keys: {}
   _Genre_aggregateQueryResponse:
     description: Response type for function Genre_aggregate
     fields:
@@ -12191,6 +12628,7 @@ object_types:
         type:
           type: named
           name: Genre_aggregate
+    foreign_keys: {}
   _Genre_by_pkQueryResponse:
     description: Response type for function Genre_by_pk
     fields:
@@ -12204,6 +12642,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre
+    foreign_keys: {}
   _InvoiceLineQueryResponse:
     description: Response type for function InvoiceLine
     fields:
@@ -12217,6 +12656,7 @@ object_types:
           element_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   _InvoiceLine_aggregateQueryResponse:
     description: Response type for function InvoiceLine_aggregate
     fields:
@@ -12228,6 +12668,7 @@ object_types:
         type:
           type: named
           name: InvoiceLine_aggregate
+    foreign_keys: {}
   _InvoiceLine_by_pkQueryResponse:
     description: Response type for function InvoiceLine_by_pk
     fields:
@@ -12241,6 +12682,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   _InvoiceQueryResponse:
     description: Response type for function Invoice
     fields:
@@ -12254,6 +12696,7 @@ object_types:
           element_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   _Invoice_aggregateQueryResponse:
     description: Response type for function Invoice_aggregate
     fields:
@@ -12265,6 +12708,7 @@ object_types:
         type:
           type: named
           name: Invoice_aggregate
+    foreign_keys: {}
   _Invoice_by_pkQueryResponse:
     description: Response type for function Invoice_by_pk
     fields:
@@ -12278,6 +12722,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   _MediaTypeQueryResponse:
     description: Response type for function MediaType
     fields:
@@ -12291,6 +12736,7 @@ object_types:
           element_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   _MediaType_aggregateQueryResponse:
     description: Response type for function MediaType_aggregate
     fields:
@@ -12302,6 +12748,7 @@ object_types:
         type:
           type: named
           name: MediaType_aggregate
+    foreign_keys: {}
   _MediaType_by_pkQueryResponse:
     description: Response type for function MediaType_by_pk
     fields:
@@ -12315,6 +12762,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   _PlaylistQueryResponse:
     description: Response type for function Playlist
     fields:
@@ -12328,6 +12776,7 @@ object_types:
           element_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   _PlaylistTrackQueryResponse:
     description: Response type for function PlaylistTrack
     fields:
@@ -12341,6 +12790,7 @@ object_types:
           element_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   _PlaylistTrack_aggregateQueryResponse:
     description: Response type for function PlaylistTrack_aggregate
     fields:
@@ -12352,6 +12802,7 @@ object_types:
         type:
           type: named
           name: PlaylistTrack_aggregate
+    foreign_keys: {}
   _PlaylistTrack_by_pkQueryResponse:
     description: Response type for function PlaylistTrack_by_pk
     fields:
@@ -12365,6 +12816,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   _Playlist_aggregateQueryResponse:
     description: Response type for function Playlist_aggregate
     fields:
@@ -12376,6 +12828,7 @@ object_types:
         type:
           type: named
           name: Playlist_aggregate
+    foreign_keys: {}
   _Playlist_by_pkQueryResponse:
     description: Response type for function Playlist_by_pk
     fields:
@@ -12389,6 +12842,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   _TrackQueryResponse:
     description: Response type for function Track
     fields:
@@ -12402,6 +12856,7 @@ object_types:
           element_type:
             type: named
             name: Track
+    foreign_keys: {}
   _Track_aggregateQueryResponse:
     description: Response type for function Track_aggregate
     fields:
@@ -12413,6 +12868,7 @@ object_types:
         type:
           type: named
           name: Track_aggregate
+    foreign_keys: {}
   _Track_by_pkQueryResponse:
     description: Response type for function Track_by_pk
     fields:
@@ -12426,6 +12882,7 @@ object_types:
           underlying_type:
             type: named
             name: Track
+    foreign_keys: {}
   _delete_AlbumMutationResponse:
     description: Response type for procedure delete_Album
     fields:
@@ -12439,6 +12896,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_mutation_response
+    foreign_keys: {}
   _delete_Album_by_pkMutationResponse:
     description: Response type for procedure delete_Album_by_pk
     fields:
@@ -12452,6 +12910,7 @@ object_types:
           underlying_type:
             type: named
             name: Album
+    foreign_keys: {}
   _delete_ArtistMutationResponse:
     description: Response type for procedure delete_Artist
     fields:
@@ -12465,6 +12924,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_mutation_response
+    foreign_keys: {}
   _delete_Artist_by_pkMutationResponse:
     description: Response type for procedure delete_Artist_by_pk
     fields:
@@ -12478,6 +12938,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist
+    foreign_keys: {}
   _delete_CustomerMutationResponse:
     description: Response type for procedure delete_Customer
     fields:
@@ -12491,6 +12952,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_mutation_response
+    foreign_keys: {}
   _delete_Customer_by_pkMutationResponse:
     description: Response type for procedure delete_Customer_by_pk
     fields:
@@ -12504,6 +12966,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer
+    foreign_keys: {}
   _delete_EmployeeMutationResponse:
     description: Response type for procedure delete_Employee
     fields:
@@ -12517,6 +12980,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_mutation_response
+    foreign_keys: {}
   _delete_Employee_by_pkMutationResponse:
     description: Response type for procedure delete_Employee_by_pk
     fields:
@@ -12530,6 +12994,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee
+    foreign_keys: {}
   _delete_GenreMutationResponse:
     description: Response type for procedure delete_Genre
     fields:
@@ -12543,6 +13008,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_mutation_response
+    foreign_keys: {}
   _delete_Genre_by_pkMutationResponse:
     description: Response type for procedure delete_Genre_by_pk
     fields:
@@ -12556,6 +13022,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre
+    foreign_keys: {}
   _delete_InvoiceLineMutationResponse:
     description: Response type for procedure delete_InvoiceLine
     fields:
@@ -12569,6 +13036,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_mutation_response
+    foreign_keys: {}
   _delete_InvoiceLine_by_pkMutationResponse:
     description: Response type for procedure delete_InvoiceLine_by_pk
     fields:
@@ -12582,6 +13050,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   _delete_InvoiceMutationResponse:
     description: Response type for procedure delete_Invoice
     fields:
@@ -12595,6 +13064,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_mutation_response
+    foreign_keys: {}
   _delete_Invoice_by_pkMutationResponse:
     description: Response type for procedure delete_Invoice_by_pk
     fields:
@@ -12608,6 +13078,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   _delete_MediaTypeMutationResponse:
     description: Response type for procedure delete_MediaType
     fields:
@@ -12621,6 +13092,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_mutation_response
+    foreign_keys: {}
   _delete_MediaType_by_pkMutationResponse:
     description: Response type for procedure delete_MediaType_by_pk
     fields:
@@ -12634,6 +13106,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   _delete_PlaylistMutationResponse:
     description: Response type for procedure delete_Playlist
     fields:
@@ -12647,6 +13120,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_mutation_response
+    foreign_keys: {}
   _delete_PlaylistTrackMutationResponse:
     description: Response type for procedure delete_PlaylistTrack
     fields:
@@ -12660,6 +13134,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_mutation_response
+    foreign_keys: {}
   _delete_PlaylistTrack_by_pkMutationResponse:
     description: Response type for procedure delete_PlaylistTrack_by_pk
     fields:
@@ -12673,6 +13148,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   _delete_Playlist_by_pkMutationResponse:
     description: Response type for procedure delete_Playlist_by_pk
     fields:
@@ -12686,6 +13162,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   _delete_TrackMutationResponse:
     description: Response type for procedure delete_Track
     fields:
@@ -12699,6 +13176,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_mutation_response
+    foreign_keys: {}
   _delete_Track_by_pkMutationResponse:
     description: Response type for procedure delete_Track_by_pk
     fields:
@@ -12712,6 +13190,7 @@ object_types:
           underlying_type:
             type: named
             name: Track
+    foreign_keys: {}
   _insert_AlbumMutationResponse:
     description: Response type for procedure insert_Album
     fields:
@@ -12725,6 +13204,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_mutation_response
+    foreign_keys: {}
   _insert_Album_oneMutationResponse:
     description: Response type for procedure insert_Album_one
     fields:
@@ -12738,6 +13218,7 @@ object_types:
           underlying_type:
             type: named
             name: Album
+    foreign_keys: {}
   _insert_ArtistMutationResponse:
     description: Response type for procedure insert_Artist
     fields:
@@ -12751,6 +13232,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_mutation_response
+    foreign_keys: {}
   _insert_Artist_oneMutationResponse:
     description: Response type for procedure insert_Artist_one
     fields:
@@ -12764,6 +13246,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist
+    foreign_keys: {}
   _insert_CustomerMutationResponse:
     description: Response type for procedure insert_Customer
     fields:
@@ -12777,6 +13260,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_mutation_response
+    foreign_keys: {}
   _insert_Customer_oneMutationResponse:
     description: Response type for procedure insert_Customer_one
     fields:
@@ -12790,6 +13274,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer
+    foreign_keys: {}
   _insert_EmployeeMutationResponse:
     description: Response type for procedure insert_Employee
     fields:
@@ -12803,6 +13288,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_mutation_response
+    foreign_keys: {}
   _insert_Employee_oneMutationResponse:
     description: Response type for procedure insert_Employee_one
     fields:
@@ -12816,6 +13302,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee
+    foreign_keys: {}
   _insert_GenreMutationResponse:
     description: Response type for procedure insert_Genre
     fields:
@@ -12829,6 +13316,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_mutation_response
+    foreign_keys: {}
   _insert_Genre_oneMutationResponse:
     description: Response type for procedure insert_Genre_one
     fields:
@@ -12842,6 +13330,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre
+    foreign_keys: {}
   _insert_InvoiceLineMutationResponse:
     description: Response type for procedure insert_InvoiceLine
     fields:
@@ -12855,6 +13344,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_mutation_response
+    foreign_keys: {}
   _insert_InvoiceLine_oneMutationResponse:
     description: Response type for procedure insert_InvoiceLine_one
     fields:
@@ -12868,6 +13358,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   _insert_InvoiceMutationResponse:
     description: Response type for procedure insert_Invoice
     fields:
@@ -12881,6 +13372,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_mutation_response
+    foreign_keys: {}
   _insert_Invoice_oneMutationResponse:
     description: Response type for procedure insert_Invoice_one
     fields:
@@ -12894,6 +13386,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   _insert_MediaTypeMutationResponse:
     description: Response type for procedure insert_MediaType
     fields:
@@ -12907,6 +13400,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_mutation_response
+    foreign_keys: {}
   _insert_MediaType_oneMutationResponse:
     description: Response type for procedure insert_MediaType_one
     fields:
@@ -12920,6 +13414,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   _insert_PlaylistMutationResponse:
     description: Response type for procedure insert_Playlist
     fields:
@@ -12933,6 +13428,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_mutation_response
+    foreign_keys: {}
   _insert_PlaylistTrackMutationResponse:
     description: Response type for procedure insert_PlaylistTrack
     fields:
@@ -12946,6 +13442,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_mutation_response
+    foreign_keys: {}
   _insert_PlaylistTrack_oneMutationResponse:
     description: Response type for procedure insert_PlaylistTrack_one
     fields:
@@ -12959,6 +13456,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   _insert_Playlist_oneMutationResponse:
     description: Response type for procedure insert_Playlist_one
     fields:
@@ -12972,6 +13470,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   _insert_TrackMutationResponse:
     description: Response type for procedure insert_Track
     fields:
@@ -12985,6 +13484,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_mutation_response
+    foreign_keys: {}
   _insert_Track_oneMutationResponse:
     description: Response type for procedure insert_Track_one
     fields:
@@ -12998,6 +13498,7 @@ object_types:
           underlying_type:
             type: named
             name: Track
+    foreign_keys: {}
   _update_AlbumMutationResponse:
     description: Response type for procedure update_Album
     fields:
@@ -13011,6 +13512,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_mutation_response
+    foreign_keys: {}
   _update_Album_by_pkMutationResponse:
     description: Response type for procedure update_Album_by_pk
     fields:
@@ -13024,6 +13526,7 @@ object_types:
           underlying_type:
             type: named
             name: Album
+    foreign_keys: {}
   _update_Album_manyMutationResponse:
     description: Response type for procedure update_Album_many
     fields:
@@ -13041,6 +13544,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Album_mutation_response
+    foreign_keys: {}
   _update_ArtistMutationResponse:
     description: Response type for procedure update_Artist
     fields:
@@ -13054,6 +13558,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_mutation_response
+    foreign_keys: {}
   _update_Artist_by_pkMutationResponse:
     description: Response type for procedure update_Artist_by_pk
     fields:
@@ -13067,6 +13572,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist
+    foreign_keys: {}
   _update_Artist_manyMutationResponse:
     description: Response type for procedure update_Artist_many
     fields:
@@ -13084,6 +13590,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Artist_mutation_response
+    foreign_keys: {}
   _update_CustomerMutationResponse:
     description: Response type for procedure update_Customer
     fields:
@@ -13097,6 +13604,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_mutation_response
+    foreign_keys: {}
   _update_Customer_by_pkMutationResponse:
     description: Response type for procedure update_Customer_by_pk
     fields:
@@ -13110,6 +13618,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer
+    foreign_keys: {}
   _update_Customer_manyMutationResponse:
     description: Response type for procedure update_Customer_many
     fields:
@@ -13127,6 +13636,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Customer_mutation_response
+    foreign_keys: {}
   _update_EmployeeMutationResponse:
     description: Response type for procedure update_Employee
     fields:
@@ -13140,6 +13650,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_mutation_response
+    foreign_keys: {}
   _update_Employee_by_pkMutationResponse:
     description: Response type for procedure update_Employee_by_pk
     fields:
@@ -13153,6 +13664,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee
+    foreign_keys: {}
   _update_Employee_manyMutationResponse:
     description: Response type for procedure update_Employee_many
     fields:
@@ -13170,6 +13682,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Employee_mutation_response
+    foreign_keys: {}
   _update_GenreMutationResponse:
     description: Response type for procedure update_Genre
     fields:
@@ -13183,6 +13696,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_mutation_response
+    foreign_keys: {}
   _update_Genre_by_pkMutationResponse:
     description: Response type for procedure update_Genre_by_pk
     fields:
@@ -13196,6 +13710,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre
+    foreign_keys: {}
   _update_Genre_manyMutationResponse:
     description: Response type for procedure update_Genre_many
     fields:
@@ -13213,6 +13728,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Genre_mutation_response
+    foreign_keys: {}
   _update_InvoiceLineMutationResponse:
     description: Response type for procedure update_InvoiceLine
     fields:
@@ -13226,6 +13742,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_mutation_response
+    foreign_keys: {}
   _update_InvoiceLine_by_pkMutationResponse:
     description: Response type for procedure update_InvoiceLine_by_pk
     fields:
@@ -13239,6 +13756,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   _update_InvoiceLine_manyMutationResponse:
     description: Response type for procedure update_InvoiceLine_many
     fields:
@@ -13256,6 +13774,7 @@ object_types:
               underlying_type:
                 type: named
                 name: InvoiceLine_mutation_response
+    foreign_keys: {}
   _update_InvoiceMutationResponse:
     description: Response type for procedure update_Invoice
     fields:
@@ -13269,6 +13788,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_mutation_response
+    foreign_keys: {}
   _update_Invoice_by_pkMutationResponse:
     description: Response type for procedure update_Invoice_by_pk
     fields:
@@ -13282,6 +13802,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   _update_Invoice_manyMutationResponse:
     description: Response type for procedure update_Invoice_many
     fields:
@@ -13299,6 +13820,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Invoice_mutation_response
+    foreign_keys: {}
   _update_MediaTypeMutationResponse:
     description: Response type for procedure update_MediaType
     fields:
@@ -13312,6 +13834,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_mutation_response
+    foreign_keys: {}
   _update_MediaType_by_pkMutationResponse:
     description: Response type for procedure update_MediaType_by_pk
     fields:
@@ -13325,6 +13848,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   _update_MediaType_manyMutationResponse:
     description: Response type for procedure update_MediaType_many
     fields:
@@ -13342,6 +13866,7 @@ object_types:
               underlying_type:
                 type: named
                 name: MediaType_mutation_response
+    foreign_keys: {}
   _update_PlaylistMutationResponse:
     description: Response type for procedure update_Playlist
     fields:
@@ -13355,6 +13880,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_mutation_response
+    foreign_keys: {}
   _update_PlaylistTrackMutationResponse:
     description: Response type for procedure update_PlaylistTrack
     fields:
@@ -13368,6 +13894,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_mutation_response
+    foreign_keys: {}
   _update_PlaylistTrack_by_pkMutationResponse:
     description: Response type for procedure update_PlaylistTrack_by_pk
     fields:
@@ -13381,6 +13908,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   _update_PlaylistTrack_manyMutationResponse:
     description: Response type for procedure update_PlaylistTrack_many
     fields:
@@ -13398,6 +13926,7 @@ object_types:
               underlying_type:
                 type: named
                 name: PlaylistTrack_mutation_response
+    foreign_keys: {}
   _update_Playlist_by_pkMutationResponse:
     description: Response type for procedure update_Playlist_by_pk
     fields:
@@ -13411,6 +13940,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   _update_Playlist_manyMutationResponse:
     description: Response type for procedure update_Playlist_many
     fields:
@@ -13428,6 +13958,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Playlist_mutation_response
+    foreign_keys: {}
   _update_TrackMutationResponse:
     description: Response type for procedure update_Track
     fields:
@@ -13441,6 +13972,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_mutation_response
+    foreign_keys: {}
   _update_Track_by_pkMutationResponse:
     description: Response type for procedure update_Track_by_pk
     fields:
@@ -13454,6 +13986,7 @@ object_types:
           underlying_type:
             type: named
             name: Track
+    foreign_keys: {}
   _update_Track_manyMutationResponse:
     description: Response type for procedure update_Track_many
     fields:
@@ -13471,6 +14004,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Track_mutation_response
+    foreign_keys: {}
   numeric_comparison_exp:
     description: "Boolean expression to compare columns of type \"numeric\". All fields are combined with logical 'AND'."
     fields:
@@ -13532,6 +14066,7 @@ object_types:
             element_type:
               type: named
               name: numeric
+    foreign_keys: {}
   subscription_root:
     fields:
       Album:
@@ -15001,6 +15536,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Track_bool_exp
+    foreign_keys: {}
   timestamp_comparison_exp:
     description: "Boolean expression to compare columns of type \"timestamp\". All fields are combined with logical 'AND'."
     fields:
@@ -15062,6 +15598,7 @@ object_types:
             element_type:
               type: named
               name: timestamp
+    foreign_keys: {}
 collections: []
 functions:
   - name: Album
@@ -17888,3 +18425,5 @@ procedures:
     result_type:
       type: named
       name: _update_Track_manyMutationResponse
+capabilities: ~
+request_arguments: ~

--- a/crates/ndc-graphql/tests/snapshots/query_builder__config-2 NDC Schema.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__config-2 NDC Schema.snap
@@ -18426,4 +18426,21 @@ procedures:
       type: named
       name: _update_Track_manyMutationResponse
 capabilities: ~
-request_arguments: ~
+request_arguments:
+  query_arguments:
+    headers:
+      description: Headers to be merged into original request headers of graphql requests
+      type:
+        type: nullable
+        underlying_type:
+          type: named
+          name: _HeaderMap
+  mutation_arguments:
+    headers:
+      description: Headers to be merged into original request headers of graphql requests
+      type:
+        type: nullable
+        underlying_type:
+          type: named
+          name: _HeaderMap
+  relational_query_arguments: {}

--- a/crates/ndc-graphql/tests/snapshots/query_builder__config-3 NDC Schema.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__config-3 NDC Schema.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ndc-graphql/tests/query_builder.rs
+assertion_line: 105
 expression: schema
 ---
 scalar_types:
@@ -10,6 +11,7 @@ scalar_types:
         - PK_Album
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Album_select_column:
     representation:
       type: enum
@@ -19,6 +21,7 @@ scalar_types:
         - Title
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Album_update_column:
     representation:
       type: enum
@@ -27,6 +30,7 @@ scalar_types:
         - Title
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Artist_constraint:
     representation:
       type: enum
@@ -34,6 +38,7 @@ scalar_types:
         - PK_Artist
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Artist_select_column:
     representation:
       type: enum
@@ -42,6 +47,7 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Artist_update_column:
     representation:
       type: enum
@@ -49,9 +55,13 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Boolean:
+    representation:
+      type: boolean
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Customer_constraint:
     representation:
       type: enum
@@ -59,6 +69,7 @@ scalar_types:
         - PK_Customer
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Customer_select_column:
     representation:
       type: enum
@@ -78,6 +89,7 @@ scalar_types:
         - SupportRepId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Customer_update_column:
     representation:
       type: enum
@@ -96,6 +108,7 @@ scalar_types:
         - SupportRepId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Employee_constraint:
     representation:
       type: enum
@@ -103,6 +116,7 @@ scalar_types:
         - PK_Employee
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Employee_select_column:
     representation:
       type: enum
@@ -124,6 +138,7 @@ scalar_types:
         - Title
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Employee_update_column:
     representation:
       type: enum
@@ -144,9 +159,13 @@ scalar_types:
         - Title
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Float:
+    representation:
+      type: float64
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Genre_constraint:
     representation:
       type: enum
@@ -154,6 +173,7 @@ scalar_types:
         - PK_Genre
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Genre_select_column:
     representation:
       type: enum
@@ -162,6 +182,7 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Genre_update_column:
     representation:
       type: enum
@@ -169,9 +190,13 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Int:
+    representation:
+      type: int32
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   InvoiceLine_constraint:
     representation:
       type: enum
@@ -179,6 +204,7 @@ scalar_types:
         - PK_InvoiceLine
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   InvoiceLine_select_column:
     representation:
       type: enum
@@ -190,6 +216,7 @@ scalar_types:
         - UnitPrice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   InvoiceLine_update_column:
     representation:
       type: enum
@@ -200,6 +227,7 @@ scalar_types:
         - UnitPrice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Invoice_constraint:
     representation:
       type: enum
@@ -207,6 +235,7 @@ scalar_types:
         - PK_Invoice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Invoice_select_column:
     representation:
       type: enum
@@ -222,6 +251,7 @@ scalar_types:
         - Total
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Invoice_update_column:
     representation:
       type: enum
@@ -236,6 +266,7 @@ scalar_types:
         - Total
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   MediaType_constraint:
     representation:
       type: enum
@@ -243,6 +274,7 @@ scalar_types:
         - PK_MediaType
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   MediaType_select_column:
     representation:
       type: enum
@@ -251,6 +283,7 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   MediaType_update_column:
     representation:
       type: enum
@@ -258,6 +291,7 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   PlaylistTrack_constraint:
     representation:
       type: enum
@@ -265,6 +299,7 @@ scalar_types:
         - PK_PlaylistTrack
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   PlaylistTrack_select_column:
     representation:
       type: enum
@@ -273,6 +308,7 @@ scalar_types:
         - TrackId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   PlaylistTrack_update_column:
     representation:
       type: enum
@@ -281,6 +317,7 @@ scalar_types:
         - TrackId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Playlist_constraint:
     representation:
       type: enum
@@ -288,6 +325,7 @@ scalar_types:
         - PK_Playlist
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Playlist_select_column:
     representation:
       type: enum
@@ -296,6 +334,7 @@ scalar_types:
         - PlaylistId
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Playlist_update_column:
     representation:
       type: enum
@@ -303,9 +342,13 @@ scalar_types:
         - Name
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   String:
+    representation:
+      type: string
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Track_constraint:
     representation:
       type: enum
@@ -313,6 +356,7 @@ scalar_types:
         - PK_Track
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Track_select_column:
     representation:
       type: enum
@@ -328,6 +372,7 @@ scalar_types:
         - UnitPrice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   Track_update_column:
     representation:
       type: enum
@@ -342,11 +387,13 @@ scalar_types:
         - UnitPrice
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   _HeaderMap:
     representation:
       type: json
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   cursor_ordering:
     representation:
       type: enum
@@ -355,9 +402,13 @@ scalar_types:
         - DESC
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   numeric:
+    representation:
+      type: json
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   order_by:
     representation:
       type: enum
@@ -370,9 +421,13 @@ scalar_types:
         - desc_nulls_last
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
   timestamp:
+    representation:
+      type: json
     aggregate_functions: {}
     comparison_operators: {}
+    extraction_functions: {}
 object_types:
   Album:
     description: "columns and relationships of \"Album\""
@@ -486,6 +541,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Track_bool_exp
+    foreign_keys: {}
   Album_aggregate:
     description: "aggregated selection of \"Album\""
     fields:
@@ -501,6 +557,7 @@ object_types:
           element_type:
             type: named
             name: Album
+    foreign_keys: {}
   Album_aggregate_bool_exp:
     fields:
       count:
@@ -509,6 +566,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_aggregate_bool_exp_count
+    foreign_keys: {}
   Album_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -535,6 +593,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Album_aggregate_fields:
     description: "aggregate fields of \"Album\""
     fields:
@@ -617,6 +676,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_variance_fields
+    foreign_keys: {}
   Album_aggregate_order_by:
     description: "order by aggregate values of table \"Album\""
     fields:
@@ -686,6 +746,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_variance_order_by
+    foreign_keys: {}
   Album_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Album\""
     fields:
@@ -702,6 +763,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_on_conflict
+    foreign_keys: {}
   Album_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -717,6 +779,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_avg_order_by:
     description: "order by avg() on columns of table \"Album\""
     fields:
@@ -732,6 +795,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_bool_exp:
     description: "Boolean expression to filter rows from the table \"Album\". All fields are combined with a logical 'AND'."
     fields:
@@ -793,6 +857,7 @@ object_types:
             element_type:
               type: named
               name: Album_bool_exp
+    foreign_keys: {}
   Album_inc_input:
     description: "input type for incrementing numeric columns in table \"Album\""
     fields:
@@ -802,6 +867,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Album_insert_input:
     description: "input type for inserting data into table \"Album\""
     fields:
@@ -829,6 +895,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_arr_rel_insert_input
+    foreign_keys: {}
   Album_max_fields:
     description: aggregate max on columns
     fields:
@@ -850,6 +917,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Album_max_order_by:
     description: "order by max() on columns of table \"Album\""
     fields:
@@ -871,6 +939,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_min_fields:
     description: aggregate min on columns
     fields:
@@ -892,6 +961,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Album_min_order_by:
     description: "order by min() on columns of table \"Album\""
     fields:
@@ -913,6 +983,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_mutation_response:
     description: "response of any mutation on the table \"Album\""
     fields:
@@ -928,6 +999,7 @@ object_types:
           element_type:
             type: named
             name: Album
+    foreign_keys: {}
   Album_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Album\""
     fields:
@@ -942,6 +1014,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_on_conflict
+    foreign_keys: {}
   Album_on_conflict:
     description: "on_conflict condition type for table \"Album\""
     fields:
@@ -961,6 +1034,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_bool_exp
+    foreign_keys: {}
   Album_order_by:
     description: "Ordering options when selecting data from \"Album\"."
     fields:
@@ -994,6 +1068,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_aggregate_order_by
+    foreign_keys: {}
   Album_pk_columns_input:
     description: "primary key columns input for table: Album"
     fields:
@@ -1001,6 +1076,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Album_set_input:
     description: "input type for updating data in table \"Album\""
     fields:
@@ -1016,6 +1092,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Album_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -1031,6 +1108,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_stddev_order_by:
     description: "order by stddev() on columns of table \"Album\""
     fields:
@@ -1046,6 +1124,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -1061,6 +1140,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Album\""
     fields:
@@ -1076,6 +1156,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -1091,6 +1172,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Album\""
     fields:
@@ -1106,6 +1188,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_stream_cursor_input:
     description: "Streaming cursor of the table \"Album\""
     fields:
@@ -1121,6 +1204,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Album_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -1142,6 +1226,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Album_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -1157,6 +1242,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Album_sum_order_by:
     description: "order by sum() on columns of table \"Album\""
     fields:
@@ -1172,6 +1258,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_updates:
     fields:
       _inc:
@@ -1193,6 +1280,7 @@ object_types:
         type:
           type: named
           name: Album_bool_exp
+    foreign_keys: {}
   Album_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -1208,6 +1296,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Album\""
     fields:
@@ -1223,6 +1312,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -1238,6 +1328,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Album\""
     fields:
@@ -1253,6 +1344,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Album_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -1268,6 +1360,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Album_variance_order_by:
     description: "order by variance() on columns of table \"Album\""
     fields:
@@ -1283,6 +1376,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Artist:
     description: "columns and relationships of \"Artist\""
     fields:
@@ -1388,6 +1482,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_aggregate:
     description: "aggregated selection of \"Artist\""
     fields:
@@ -1403,6 +1498,7 @@ object_types:
           element_type:
             type: named
             name: Artist
+    foreign_keys: {}
   Artist_aggregate_fields:
     description: "aggregate fields of \"Artist\""
     fields:
@@ -1485,6 +1581,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_variance_fields
+    foreign_keys: {}
   Artist_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -1494,6 +1591,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_bool_exp:
     description: "Boolean expression to filter rows from the table \"Artist\". All fields are combined with a logical 'AND'."
     fields:
@@ -1543,6 +1641,7 @@ object_types:
             element_type:
               type: named
               name: Artist_bool_exp
+    foreign_keys: {}
   Artist_insert_input:
     description: "input type for inserting data into table \"Artist\""
     fields:
@@ -1558,6 +1657,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_max_fields:
     description: aggregate max on columns
     fields:
@@ -1573,6 +1673,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_min_fields:
     description: aggregate min on columns
     fields:
@@ -1588,6 +1689,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_mutation_response:
     description: "response of any mutation on the table \"Artist\""
     fields:
@@ -1603,6 +1705,7 @@ object_types:
           element_type:
             type: named
             name: Artist
+    foreign_keys: {}
   Artist_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Artist\""
     fields:
@@ -1617,6 +1720,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_on_conflict
+    foreign_keys: {}
   Artist_on_conflict:
     description: "on_conflict condition type for table \"Artist\""
     fields:
@@ -1636,6 +1740,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_bool_exp
+    foreign_keys: {}
   Artist_order_by:
     description: "Ordering options when selecting data from \"Artist\"."
     fields:
@@ -1657,6 +1762,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Artist_pk_columns_input:
     description: "primary key columns input for table: Artist"
     fields:
@@ -1664,6 +1770,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Artist_set_input:
     description: "input type for updating data in table \"Artist\""
     fields:
@@ -1673,6 +1780,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -1682,6 +1790,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -1691,6 +1800,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -1700,6 +1810,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_stream_cursor_input:
     description: "Streaming cursor of the table \"Artist\""
     fields:
@@ -1715,6 +1826,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Artist_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -1730,6 +1842,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Artist_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -1739,6 +1852,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Artist_updates:
     fields:
       _set:
@@ -1753,6 +1867,7 @@ object_types:
         type:
           type: named
           name: Artist_bool_exp
+    foreign_keys: {}
   Artist_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -1762,6 +1877,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -1771,6 +1887,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Artist_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -1780,6 +1897,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer:
     description: "columns and relationships of \"Customer\""
     fields:
@@ -1952,6 +2070,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_aggregate:
     description: "aggregated selection of \"Customer\""
     fields:
@@ -1967,6 +2086,7 @@ object_types:
           element_type:
             type: named
             name: Customer
+    foreign_keys: {}
   Customer_aggregate_bool_exp:
     fields:
       count:
@@ -1975,6 +2095,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_aggregate_bool_exp_count
+    foreign_keys: {}
   Customer_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -2001,6 +2122,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Customer_aggregate_fields:
     description: "aggregate fields of \"Customer\""
     fields:
@@ -2083,6 +2205,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_variance_fields
+    foreign_keys: {}
   Customer_aggregate_order_by:
     description: "order by aggregate values of table \"Customer\""
     fields:
@@ -2152,6 +2275,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_variance_order_by
+    foreign_keys: {}
   Customer_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Customer\""
     fields:
@@ -2168,6 +2292,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_on_conflict
+    foreign_keys: {}
   Customer_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -2183,6 +2308,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_avg_order_by:
     description: "order by avg() on columns of table \"Customer\""
     fields:
@@ -2198,6 +2324,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_bool_exp:
     description: "Boolean expression to filter rows from the table \"Customer\". All fields are combined with a logical 'AND'."
     fields:
@@ -2319,6 +2446,7 @@ object_types:
             element_type:
               type: named
               name: Customer_bool_exp
+    foreign_keys: {}
   Customer_inc_input:
     description: "input type for incrementing numeric columns in table \"Customer\""
     fields:
@@ -2328,6 +2456,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_insert_input:
     description: "input type for inserting data into table \"Customer\""
     fields:
@@ -2415,6 +2544,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_max_fields:
     description: aggregate max on columns
     fields:
@@ -2496,6 +2626,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_max_order_by:
     description: "order by max() on columns of table \"Customer\""
     fields:
@@ -2577,6 +2708,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_min_fields:
     description: aggregate min on columns
     fields:
@@ -2658,6 +2790,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_min_order_by:
     description: "order by min() on columns of table \"Customer\""
     fields:
@@ -2739,6 +2872,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_mutation_response:
     description: "response of any mutation on the table \"Customer\""
     fields:
@@ -2754,6 +2888,7 @@ object_types:
           element_type:
             type: named
             name: Customer
+    foreign_keys: {}
   Customer_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Customer\""
     fields:
@@ -2768,6 +2903,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_on_conflict
+    foreign_keys: {}
   Customer_on_conflict:
     description: "on_conflict condition type for table \"Customer\""
     fields:
@@ -2787,6 +2923,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_bool_exp
+    foreign_keys: {}
   Customer_order_by:
     description: "Ordering options when selecting data from \"Customer\"."
     fields:
@@ -2880,6 +3017,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_pk_columns_input:
     description: "primary key columns input for table: Customer"
     fields:
@@ -2887,6 +3025,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Customer_set_input:
     description: "input type for updating data in table \"Customer\""
     fields:
@@ -2962,6 +3101,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -2977,6 +3117,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_stddev_order_by:
     description: "order by stddev() on columns of table \"Customer\""
     fields:
@@ -2992,6 +3133,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -3007,6 +3149,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Customer\""
     fields:
@@ -3022,6 +3165,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -3037,6 +3181,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Customer\""
     fields:
@@ -3052,6 +3197,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_stream_cursor_input:
     description: "Streaming cursor of the table \"Customer\""
     fields:
@@ -3067,6 +3213,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Customer_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -3148,6 +3295,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -3163,6 +3311,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Customer_sum_order_by:
     description: "order by sum() on columns of table \"Customer\""
     fields:
@@ -3178,6 +3327,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_updates:
     fields:
       _inc:
@@ -3199,6 +3349,7 @@ object_types:
         type:
           type: named
           name: Customer_bool_exp
+    foreign_keys: {}
   Customer_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -3214,6 +3365,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Customer\""
     fields:
@@ -3229,6 +3381,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -3244,6 +3397,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Customer\""
     fields:
@@ -3259,6 +3413,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Customer_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -3274,6 +3429,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Customer_variance_order_by:
     description: "order by variance() on columns of table \"Customer\""
     fields:
@@ -3289,6 +3445,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee:
     description: "columns and relationships of \"Employee\""
     fields:
@@ -3567,6 +3724,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_aggregate:
     description: "aggregated selection of \"Employee\""
     fields:
@@ -3582,6 +3740,7 @@ object_types:
           element_type:
             type: named
             name: Employee
+    foreign_keys: {}
   Employee_aggregate_bool_exp:
     fields:
       count:
@@ -3590,6 +3749,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_aggregate_bool_exp_count
+    foreign_keys: {}
   Employee_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -3616,6 +3776,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Employee_aggregate_fields:
     description: "aggregate fields of \"Employee\""
     fields:
@@ -3698,6 +3859,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_variance_fields
+    foreign_keys: {}
   Employee_aggregate_order_by:
     description: "order by aggregate values of table \"Employee\""
     fields:
@@ -3767,6 +3929,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_variance_order_by
+    foreign_keys: {}
   Employee_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Employee\""
     fields:
@@ -3783,6 +3946,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_on_conflict
+    foreign_keys: {}
   Employee_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -3798,6 +3962,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_avg_order_by:
     description: "order by avg() on columns of table \"Employee\""
     fields:
@@ -3813,6 +3978,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_bool_exp:
     description: "Boolean expression to filter rows from the table \"Employee\". All fields are combined with a logical 'AND'."
     fields:
@@ -3958,6 +4124,7 @@ object_types:
             element_type:
               type: named
               name: Employee_bool_exp
+    foreign_keys: {}
   Employee_inc_input:
     description: "input type for incrementing numeric columns in table \"Employee\""
     fields:
@@ -3967,6 +4134,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Employee_insert_input:
     description: "input type for inserting data into table \"Employee\""
     fields:
@@ -4072,6 +4240,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_max_fields:
     description: aggregate max on columns
     fields:
@@ -4165,6 +4334,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_max_order_by:
     description: "order by max() on columns of table \"Employee\""
     fields:
@@ -4258,6 +4428,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_min_fields:
     description: aggregate min on columns
     fields:
@@ -4351,6 +4522,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_min_order_by:
     description: "order by min() on columns of table \"Employee\""
     fields:
@@ -4444,6 +4616,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_mutation_response:
     description: "response of any mutation on the table \"Employee\""
     fields:
@@ -4459,6 +4632,7 @@ object_types:
           element_type:
             type: named
             name: Employee
+    foreign_keys: {}
   Employee_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Employee\""
     fields:
@@ -4473,6 +4647,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_on_conflict
+    foreign_keys: {}
   Employee_on_conflict:
     description: "on_conflict condition type for table \"Employee\""
     fields:
@@ -4492,6 +4667,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_bool_exp
+    foreign_keys: {}
   Employee_order_by:
     description: "Ordering options when selecting data from \"Employee\"."
     fields:
@@ -4603,6 +4779,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_pk_columns_input:
     description: "primary key columns input for table: Employee"
     fields:
@@ -4610,6 +4787,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Employee_set_input:
     description: "input type for updating data in table \"Employee\""
     fields:
@@ -4697,6 +4875,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -4712,6 +4891,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_stddev_order_by:
     description: "order by stddev() on columns of table \"Employee\""
     fields:
@@ -4727,6 +4907,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -4742,6 +4923,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Employee\""
     fields:
@@ -4757,6 +4939,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -4772,6 +4955,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Employee\""
     fields:
@@ -4787,6 +4971,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_stream_cursor_input:
     description: "Streaming cursor of the table \"Employee\""
     fields:
@@ -4802,6 +4987,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Employee_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -4895,6 +5081,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Employee_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -4910,6 +5097,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Employee_sum_order_by:
     description: "order by sum() on columns of table \"Employee\""
     fields:
@@ -4925,6 +5113,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_updates:
     fields:
       _inc:
@@ -4946,6 +5135,7 @@ object_types:
         type:
           type: named
           name: Employee_bool_exp
+    foreign_keys: {}
   Employee_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -4961,6 +5151,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Employee\""
     fields:
@@ -4976,6 +5167,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -4991,6 +5183,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Employee\""
     fields:
@@ -5006,6 +5199,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Employee_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -5021,6 +5215,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Employee_variance_order_by:
     description: "order by variance() on columns of table \"Employee\""
     fields:
@@ -5036,6 +5231,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Genre:
     description: "columns and relationships of \"Genre\""
     fields:
@@ -5141,6 +5337,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Track_bool_exp
+    foreign_keys: {}
   Genre_aggregate:
     description: "aggregated selection of \"Genre\""
     fields:
@@ -5156,6 +5353,7 @@ object_types:
           element_type:
             type: named
             name: Genre
+    foreign_keys: {}
   Genre_aggregate_fields:
     description: "aggregate fields of \"Genre\""
     fields:
@@ -5238,6 +5436,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_variance_fields
+    foreign_keys: {}
   Genre_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -5247,6 +5446,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_bool_exp:
     description: "Boolean expression to filter rows from the table \"Genre\". All fields are combined with a logical 'AND'."
     fields:
@@ -5296,6 +5496,7 @@ object_types:
             element_type:
               type: named
               name: Genre_bool_exp
+    foreign_keys: {}
   Genre_insert_input:
     description: "input type for inserting data into table \"Genre\""
     fields:
@@ -5311,6 +5512,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_arr_rel_insert_input
+    foreign_keys: {}
   Genre_max_fields:
     description: aggregate max on columns
     fields:
@@ -5326,6 +5528,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Genre_min_fields:
     description: aggregate min on columns
     fields:
@@ -5341,6 +5544,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Genre_mutation_response:
     description: "response of any mutation on the table \"Genre\""
     fields:
@@ -5356,6 +5560,7 @@ object_types:
           element_type:
             type: named
             name: Genre
+    foreign_keys: {}
   Genre_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Genre\""
     fields:
@@ -5370,6 +5575,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_on_conflict
+    foreign_keys: {}
   Genre_on_conflict:
     description: "on_conflict condition type for table \"Genre\""
     fields:
@@ -5389,6 +5595,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_bool_exp
+    foreign_keys: {}
   Genre_order_by:
     description: "Ordering options when selecting data from \"Genre\"."
     fields:
@@ -5410,6 +5617,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_aggregate_order_by
+    foreign_keys: {}
   Genre_pk_columns_input:
     description: "primary key columns input for table: Genre"
     fields:
@@ -5417,6 +5625,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Genre_set_input:
     description: "input type for updating data in table \"Genre\""
     fields:
@@ -5426,6 +5635,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Genre_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -5435,6 +5645,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -5444,6 +5655,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -5453,6 +5665,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_stream_cursor_input:
     description: "Streaming cursor of the table \"Genre\""
     fields:
@@ -5468,6 +5681,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Genre_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -5483,6 +5697,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Genre_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -5492,6 +5707,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Genre_updates:
     fields:
       _set:
@@ -5506,6 +5722,7 @@ object_types:
         type:
           type: named
           name: Genre_bool_exp
+    foreign_keys: {}
   Genre_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -5515,6 +5732,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -5524,6 +5742,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Genre_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -5533,6 +5752,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Int_comparison_exp:
     description: "Boolean expression to compare columns of type \"Int\". All fields are combined with logical 'AND'."
     fields:
@@ -5594,6 +5814,7 @@ object_types:
             element_type:
               type: named
               name: Int
+    foreign_keys: {}
   Invoice:
     description: "columns and relationships of \"Invoice\""
     fields:
@@ -5740,6 +5961,7 @@ object_types:
         type:
           type: named
           name: numeric
+    foreign_keys: {}
   InvoiceLine:
     description: "columns and relationships of \"InvoiceLine\""
     fields:
@@ -5773,6 +5995,7 @@ object_types:
         type:
           type: named
           name: numeric
+    foreign_keys: {}
   InvoiceLine_aggregate:
     description: "aggregated selection of \"InvoiceLine\""
     fields:
@@ -5788,6 +6011,7 @@ object_types:
           element_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   InvoiceLine_aggregate_bool_exp:
     fields:
       count:
@@ -5796,6 +6020,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_aggregate_bool_exp_count
+    foreign_keys: {}
   InvoiceLine_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -5822,6 +6047,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   InvoiceLine_aggregate_fields:
     description: "aggregate fields of \"InvoiceLine\""
     fields:
@@ -5904,6 +6130,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_variance_fields
+    foreign_keys: {}
   InvoiceLine_aggregate_order_by:
     description: "order by aggregate values of table \"InvoiceLine\""
     fields:
@@ -5973,6 +6200,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_variance_order_by
+    foreign_keys: {}
   InvoiceLine_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"InvoiceLine\""
     fields:
@@ -5989,6 +6217,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_on_conflict
+    foreign_keys: {}
   InvoiceLine_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -6022,6 +6251,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_avg_order_by:
     description: "order by avg() on columns of table \"InvoiceLine\""
     fields:
@@ -6055,6 +6285,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_bool_exp:
     description: "Boolean expression to filter rows from the table \"InvoiceLine\". All fields are combined with a logical 'AND'."
     fields:
@@ -6122,6 +6353,7 @@ object_types:
             element_type:
               type: named
               name: InvoiceLine_bool_exp
+    foreign_keys: {}
   InvoiceLine_inc_input:
     description: "input type for incrementing numeric columns in table \"InvoiceLine\""
     fields:
@@ -6149,6 +6381,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_insert_input:
     description: "input type for inserting data into table \"InvoiceLine\""
     fields:
@@ -6188,6 +6421,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_max_fields:
     description: aggregate max on columns
     fields:
@@ -6221,6 +6455,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_max_order_by:
     description: "order by max() on columns of table \"InvoiceLine\""
     fields:
@@ -6254,6 +6489,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_min_fields:
     description: aggregate min on columns
     fields:
@@ -6287,6 +6523,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_min_order_by:
     description: "order by min() on columns of table \"InvoiceLine\""
     fields:
@@ -6320,6 +6557,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_mutation_response:
     description: "response of any mutation on the table \"InvoiceLine\""
     fields:
@@ -6335,6 +6573,7 @@ object_types:
           element_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   InvoiceLine_on_conflict:
     description: "on_conflict condition type for table \"InvoiceLine\""
     fields:
@@ -6354,6 +6593,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_bool_exp
+    foreign_keys: {}
   InvoiceLine_order_by:
     description: "Ordering options when selecting data from \"InvoiceLine\"."
     fields:
@@ -6399,6 +6639,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_pk_columns_input:
     description: "primary key columns input for table: InvoiceLine"
     fields:
@@ -6406,6 +6647,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   InvoiceLine_set_input:
     description: "input type for updating data in table \"InvoiceLine\""
     fields:
@@ -6433,6 +6675,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -6466,6 +6709,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_stddev_order_by:
     description: "order by stddev() on columns of table \"InvoiceLine\""
     fields:
@@ -6499,6 +6743,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -6532,6 +6777,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"InvoiceLine\""
     fields:
@@ -6565,6 +6811,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -6598,6 +6845,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"InvoiceLine\""
     fields:
@@ -6631,6 +6879,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_stream_cursor_input:
     description: "Streaming cursor of the table \"InvoiceLine\""
     fields:
@@ -6646,6 +6895,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   InvoiceLine_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -6679,6 +6929,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -6712,6 +6963,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   InvoiceLine_sum_order_by:
     description: "order by sum() on columns of table \"InvoiceLine\""
     fields:
@@ -6745,6 +6997,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_updates:
     fields:
       _inc:
@@ -6766,6 +7019,7 @@ object_types:
         type:
           type: named
           name: InvoiceLine_bool_exp
+    foreign_keys: {}
   InvoiceLine_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -6799,6 +7053,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_var_pop_order_by:
     description: "order by var_pop() on columns of table \"InvoiceLine\""
     fields:
@@ -6832,6 +7087,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -6865,6 +7121,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_var_samp_order_by:
     description: "order by var_samp() on columns of table \"InvoiceLine\""
     fields:
@@ -6898,6 +7155,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   InvoiceLine_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -6931,6 +7189,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   InvoiceLine_variance_order_by:
     description: "order by variance() on columns of table \"InvoiceLine\""
     fields:
@@ -6964,6 +7223,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_aggregate:
     description: "aggregated selection of \"Invoice\""
     fields:
@@ -6979,6 +7239,7 @@ object_types:
           element_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   Invoice_aggregate_bool_exp:
     fields:
       count:
@@ -6987,6 +7248,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_aggregate_bool_exp_count
+    foreign_keys: {}
   Invoice_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -7013,6 +7275,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Invoice_aggregate_fields:
     description: "aggregate fields of \"Invoice\""
     fields:
@@ -7095,6 +7358,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_variance_fields
+    foreign_keys: {}
   Invoice_aggregate_order_by:
     description: "order by aggregate values of table \"Invoice\""
     fields:
@@ -7164,6 +7428,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_variance_order_by
+    foreign_keys: {}
   Invoice_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Invoice\""
     fields:
@@ -7180,6 +7445,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_on_conflict
+    foreign_keys: {}
   Invoice_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -7201,6 +7467,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_avg_order_by:
     description: "order by avg() on columns of table \"Invoice\""
     fields:
@@ -7222,6 +7489,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_bool_exp:
     description: "Boolean expression to filter rows from the table \"Invoice\". All fields are combined with a logical 'AND'."
     fields:
@@ -7319,6 +7587,7 @@ object_types:
             element_type:
               type: named
               name: Invoice_bool_exp
+    foreign_keys: {}
   Invoice_inc_input:
     description: "input type for incrementing numeric columns in table \"Invoice\""
     fields:
@@ -7334,6 +7603,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_insert_input:
     description: "input type for inserting data into table \"Invoice\""
     fields:
@@ -7397,6 +7667,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_max_fields:
     description: aggregate max on columns
     fields:
@@ -7454,6 +7725,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_max_order_by:
     description: "order by max() on columns of table \"Invoice\""
     fields:
@@ -7511,6 +7783,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_min_fields:
     description: aggregate min on columns
     fields:
@@ -7568,6 +7841,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_min_order_by:
     description: "order by min() on columns of table \"Invoice\""
     fields:
@@ -7625,6 +7899,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_mutation_response:
     description: "response of any mutation on the table \"Invoice\""
     fields:
@@ -7640,6 +7915,7 @@ object_types:
           element_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   Invoice_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Invoice\""
     fields:
@@ -7654,6 +7930,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_on_conflict
+    foreign_keys: {}
   Invoice_on_conflict:
     description: "on_conflict condition type for table \"Invoice\""
     fields:
@@ -7673,6 +7950,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_bool_exp
+    foreign_keys: {}
   Invoice_order_by:
     description: "Ordering options when selecting data from \"Invoice\"."
     fields:
@@ -7742,6 +8020,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_pk_columns_input:
     description: "primary key columns input for table: Invoice"
     fields:
@@ -7749,6 +8028,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Invoice_set_input:
     description: "input type for updating data in table \"Invoice\""
     fields:
@@ -7800,6 +8080,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -7821,6 +8102,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_stddev_order_by:
     description: "order by stddev() on columns of table \"Invoice\""
     fields:
@@ -7842,6 +8124,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -7863,6 +8146,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Invoice\""
     fields:
@@ -7884,6 +8168,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -7905,6 +8190,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Invoice\""
     fields:
@@ -7926,6 +8212,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_stream_cursor_input:
     description: "Streaming cursor of the table \"Invoice\""
     fields:
@@ -7941,6 +8228,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Invoice_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -7998,6 +8286,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -8019,6 +8308,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Invoice_sum_order_by:
     description: "order by sum() on columns of table \"Invoice\""
     fields:
@@ -8040,6 +8330,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_updates:
     fields:
       _inc:
@@ -8061,6 +8352,7 @@ object_types:
         type:
           type: named
           name: Invoice_bool_exp
+    foreign_keys: {}
   Invoice_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -8082,6 +8374,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Invoice\""
     fields:
@@ -8103,6 +8396,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -8124,6 +8418,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Invoice\""
     fields:
@@ -8145,6 +8440,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Invoice_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -8166,6 +8462,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Invoice_variance_order_by:
     description: "order by variance() on columns of table \"Invoice\""
     fields:
@@ -8187,6 +8484,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   MediaType:
     description: "columns and relationships of \"MediaType\""
     fields:
@@ -8292,6 +8590,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Track_bool_exp
+    foreign_keys: {}
   MediaType_aggregate:
     description: "aggregated selection of \"MediaType\""
     fields:
@@ -8307,6 +8606,7 @@ object_types:
           element_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   MediaType_aggregate_fields:
     description: "aggregate fields of \"MediaType\""
     fields:
@@ -8389,6 +8689,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_variance_fields
+    foreign_keys: {}
   MediaType_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -8398,6 +8699,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_bool_exp:
     description: "Boolean expression to filter rows from the table \"MediaType\". All fields are combined with a logical 'AND'."
     fields:
@@ -8447,6 +8749,7 @@ object_types:
             element_type:
               type: named
               name: MediaType_bool_exp
+    foreign_keys: {}
   MediaType_insert_input:
     description: "input type for inserting data into table \"MediaType\""
     fields:
@@ -8462,6 +8765,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_arr_rel_insert_input
+    foreign_keys: {}
   MediaType_max_fields:
     description: aggregate max on columns
     fields:
@@ -8477,6 +8781,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   MediaType_min_fields:
     description: aggregate min on columns
     fields:
@@ -8492,6 +8797,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   MediaType_mutation_response:
     description: "response of any mutation on the table \"MediaType\""
     fields:
@@ -8507,6 +8813,7 @@ object_types:
           element_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   MediaType_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"MediaType\""
     fields:
@@ -8521,6 +8828,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_on_conflict
+    foreign_keys: {}
   MediaType_on_conflict:
     description: "on_conflict condition type for table \"MediaType\""
     fields:
@@ -8540,6 +8848,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_bool_exp
+    foreign_keys: {}
   MediaType_order_by:
     description: "Ordering options when selecting data from \"MediaType\"."
     fields:
@@ -8561,6 +8870,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_aggregate_order_by
+    foreign_keys: {}
   MediaType_pk_columns_input:
     description: "primary key columns input for table: MediaType"
     fields:
@@ -8568,6 +8878,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   MediaType_set_input:
     description: "input type for updating data in table \"MediaType\""
     fields:
@@ -8577,6 +8888,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   MediaType_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -8586,6 +8898,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -8595,6 +8908,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -8604,6 +8918,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_stream_cursor_input:
     description: "Streaming cursor of the table \"MediaType\""
     fields:
@@ -8619,6 +8934,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   MediaType_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -8634,6 +8950,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   MediaType_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -8643,6 +8960,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   MediaType_updates:
     fields:
       _set:
@@ -8657,6 +8975,7 @@ object_types:
         type:
           type: named
           name: MediaType_bool_exp
+    foreign_keys: {}
   MediaType_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -8666,6 +8985,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -8675,6 +8995,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   MediaType_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -8684,6 +9005,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist:
     description: "columns and relationships of \"Playlist\""
     fields:
@@ -8789,6 +9111,7 @@ object_types:
               underlying_type:
                 type: named
                 name: PlaylistTrack_bool_exp
+    foreign_keys: {}
   PlaylistTrack:
     description: "columns and relationships of \"PlaylistTrack\""
     fields:
@@ -8810,6 +9133,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   PlaylistTrack_aggregate:
     description: "aggregated selection of \"PlaylistTrack\""
     fields:
@@ -8825,6 +9149,7 @@ object_types:
           element_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   PlaylistTrack_aggregate_bool_exp:
     fields:
       count:
@@ -8833,6 +9158,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_aggregate_bool_exp_count
+    foreign_keys: {}
   PlaylistTrack_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -8859,6 +9185,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   PlaylistTrack_aggregate_fields:
     description: "aggregate fields of \"PlaylistTrack\""
     fields:
@@ -8941,6 +9268,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_variance_fields
+    foreign_keys: {}
   PlaylistTrack_aggregate_order_by:
     description: "order by aggregate values of table \"PlaylistTrack\""
     fields:
@@ -9010,6 +9338,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_variance_order_by
+    foreign_keys: {}
   PlaylistTrack_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"PlaylistTrack\""
     fields:
@@ -9026,6 +9355,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_on_conflict
+    foreign_keys: {}
   PlaylistTrack_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -9041,6 +9371,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_avg_order_by:
     description: "order by avg() on columns of table \"PlaylistTrack\""
     fields:
@@ -9056,6 +9387,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_bool_exp:
     description: "Boolean expression to filter rows from the table \"PlaylistTrack\". All fields are combined with a logical 'AND'."
     fields:
@@ -9105,6 +9437,7 @@ object_types:
             element_type:
               type: named
               name: PlaylistTrack_bool_exp
+    foreign_keys: {}
   PlaylistTrack_inc_input:
     description: "input type for incrementing numeric columns in table \"PlaylistTrack\""
     fields:
@@ -9120,6 +9453,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_insert_input:
     description: "input type for inserting data into table \"PlaylistTrack\""
     fields:
@@ -9147,6 +9481,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_max_fields:
     description: aggregate max on columns
     fields:
@@ -9162,6 +9497,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_max_order_by:
     description: "order by max() on columns of table \"PlaylistTrack\""
     fields:
@@ -9177,6 +9513,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_min_fields:
     description: aggregate min on columns
     fields:
@@ -9192,6 +9529,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_min_order_by:
     description: "order by min() on columns of table \"PlaylistTrack\""
     fields:
@@ -9207,6 +9545,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_mutation_response:
     description: "response of any mutation on the table \"PlaylistTrack\""
     fields:
@@ -9222,6 +9561,7 @@ object_types:
           element_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   PlaylistTrack_on_conflict:
     description: "on_conflict condition type for table \"PlaylistTrack\""
     fields:
@@ -9241,6 +9581,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_bool_exp
+    foreign_keys: {}
   PlaylistTrack_order_by:
     description: "Ordering options when selecting data from \"PlaylistTrack\"."
     fields:
@@ -9268,6 +9609,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_pk_columns_input:
     description: "primary key columns input for table: PlaylistTrack"
     fields:
@@ -9279,6 +9621,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   PlaylistTrack_set_input:
     description: "input type for updating data in table \"PlaylistTrack\""
     fields:
@@ -9294,6 +9637,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -9309,6 +9653,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_stddev_order_by:
     description: "order by stddev() on columns of table \"PlaylistTrack\""
     fields:
@@ -9324,6 +9669,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -9339,6 +9685,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"PlaylistTrack\""
     fields:
@@ -9354,6 +9701,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -9369,6 +9717,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"PlaylistTrack\""
     fields:
@@ -9384,6 +9733,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_stream_cursor_input:
     description: "Streaming cursor of the table \"PlaylistTrack\""
     fields:
@@ -9399,6 +9749,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   PlaylistTrack_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -9414,6 +9765,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -9429,6 +9781,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   PlaylistTrack_sum_order_by:
     description: "order by sum() on columns of table \"PlaylistTrack\""
     fields:
@@ -9444,6 +9797,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_updates:
     fields:
       _inc:
@@ -9465,6 +9819,7 @@ object_types:
         type:
           type: named
           name: PlaylistTrack_bool_exp
+    foreign_keys: {}
   PlaylistTrack_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -9480,6 +9835,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_var_pop_order_by:
     description: "order by var_pop() on columns of table \"PlaylistTrack\""
     fields:
@@ -9495,6 +9851,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -9510,6 +9867,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_var_samp_order_by:
     description: "order by var_samp() on columns of table \"PlaylistTrack\""
     fields:
@@ -9525,6 +9883,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   PlaylistTrack_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -9540,6 +9899,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   PlaylistTrack_variance_order_by:
     description: "order by variance() on columns of table \"PlaylistTrack\""
     fields:
@@ -9555,6 +9915,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Playlist_aggregate:
     description: "aggregated selection of \"Playlist\""
     fields:
@@ -9570,6 +9931,7 @@ object_types:
           element_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   Playlist_aggregate_fields:
     description: "aggregate fields of \"Playlist\""
     fields:
@@ -9652,6 +10014,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_variance_fields
+    foreign_keys: {}
   Playlist_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -9661,6 +10024,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_bool_exp:
     description: "Boolean expression to filter rows from the table \"Playlist\". All fields are combined with a logical 'AND'."
     fields:
@@ -9710,6 +10074,7 @@ object_types:
             element_type:
               type: named
               name: Playlist_bool_exp
+    foreign_keys: {}
   Playlist_insert_input:
     description: "input type for inserting data into table \"Playlist\""
     fields:
@@ -9725,6 +10090,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_arr_rel_insert_input
+    foreign_keys: {}
   Playlist_max_fields:
     description: aggregate max on columns
     fields:
@@ -9740,6 +10106,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Playlist_min_fields:
     description: aggregate min on columns
     fields:
@@ -9755,6 +10122,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Playlist_mutation_response:
     description: "response of any mutation on the table \"Playlist\""
     fields:
@@ -9770,6 +10138,7 @@ object_types:
           element_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   Playlist_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Playlist\""
     fields:
@@ -9784,6 +10153,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_on_conflict
+    foreign_keys: {}
   Playlist_on_conflict:
     description: "on_conflict condition type for table \"Playlist\""
     fields:
@@ -9803,6 +10173,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_bool_exp
+    foreign_keys: {}
   Playlist_order_by:
     description: "Ordering options when selecting data from \"Playlist\"."
     fields:
@@ -9824,6 +10195,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_aggregate_order_by
+    foreign_keys: {}
   Playlist_pk_columns_input:
     description: "primary key columns input for table: Playlist"
     fields:
@@ -9831,6 +10203,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Playlist_set_input:
     description: "input type for updating data in table \"Playlist\""
     fields:
@@ -9840,6 +10213,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Playlist_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -9849,6 +10223,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -9858,6 +10233,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -9867,6 +10243,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_stream_cursor_input:
     description: "Streaming cursor of the table \"Playlist\""
     fields:
@@ -9882,6 +10259,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Playlist_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -9897,6 +10275,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Playlist_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -9906,6 +10285,7 @@ object_types:
           underlying_type:
             type: named
             name: Int
+    foreign_keys: {}
   Playlist_updates:
     fields:
       _set:
@@ -9920,6 +10300,7 @@ object_types:
         type:
           type: named
           name: Playlist_bool_exp
+    foreign_keys: {}
   Playlist_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -9929,6 +10310,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -9938,6 +10320,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Playlist_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -9947,6 +10330,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   String_comparison_exp:
     description: "Boolean expression to compare columns of type \"String\". All fields are combined with logical 'AND'."
     fields:
@@ -10078,6 +10462,7 @@ object_types:
           underlying_type:
             type: named
             name: String
+    foreign_keys: {}
   Track:
     description: "columns and relationships of \"Track\""
     fields:
@@ -10328,6 +10713,7 @@ object_types:
         type:
           type: named
           name: numeric
+    foreign_keys: {}
   Track_aggregate:
     description: "aggregated selection of \"Track\""
     fields:
@@ -10343,6 +10729,7 @@ object_types:
           element_type:
             type: named
             name: Track
+    foreign_keys: {}
   Track_aggregate_bool_exp:
     fields:
       count:
@@ -10351,6 +10738,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_aggregate_bool_exp_count
+    foreign_keys: {}
   Track_aggregate_bool_exp_count:
     fields:
       arguments:
@@ -10377,6 +10765,7 @@ object_types:
         type:
           type: named
           name: Int_comparison_exp
+    foreign_keys: {}
   Track_aggregate_fields:
     description: "aggregate fields of \"Track\""
     fields:
@@ -10459,6 +10848,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_variance_fields
+    foreign_keys: {}
   Track_aggregate_order_by:
     description: "order by aggregate values of table \"Track\""
     fields:
@@ -10528,6 +10918,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_variance_order_by
+    foreign_keys: {}
   Track_arr_rel_insert_input:
     description: "input type for inserting array relation for remote table \"Track\""
     fields:
@@ -10544,6 +10935,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_on_conflict
+    foreign_keys: {}
   Track_avg_fields:
     description: aggregate avg on columns
     fields:
@@ -10589,6 +10981,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_avg_order_by:
     description: "order by avg() on columns of table \"Track\""
     fields:
@@ -10634,6 +11027,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_bool_exp:
     description: "Boolean expression to filter rows from the table \"Track\". All fields are combined with a logical 'AND'."
     fields:
@@ -10755,6 +11149,7 @@ object_types:
             element_type:
               type: named
               name: Track_bool_exp
+    foreign_keys: {}
   Track_inc_input:
     description: "input type for incrementing numeric columns in table \"Track\""
     fields:
@@ -10794,6 +11189,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_insert_input:
     description: "input type for inserting data into table \"Track\""
     fields:
@@ -10875,6 +11271,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_max_fields:
     description: aggregate max on columns
     fields:
@@ -10932,6 +11329,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_max_order_by:
     description: "order by max() on columns of table \"Track\""
     fields:
@@ -10989,6 +11387,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_min_fields:
     description: aggregate min on columns
     fields:
@@ -11046,6 +11445,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_min_order_by:
     description: "order by min() on columns of table \"Track\""
     fields:
@@ -11103,6 +11503,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_mutation_response:
     description: "response of any mutation on the table \"Track\""
     fields:
@@ -11118,6 +11519,7 @@ object_types:
           element_type:
             type: named
             name: Track
+    foreign_keys: {}
   Track_obj_rel_insert_input:
     description: "input type for inserting object relation for remote table \"Track\""
     fields:
@@ -11132,6 +11534,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_on_conflict
+    foreign_keys: {}
   Track_on_conflict:
     description: "on_conflict condition type for table \"Track\""
     fields:
@@ -11151,6 +11554,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_bool_exp
+    foreign_keys: {}
   Track_order_by:
     description: "Ordering options when selecting data from \"Track\"."
     fields:
@@ -11238,6 +11642,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_pk_columns_input:
     description: "primary key columns input for table: Track"
     fields:
@@ -11245,6 +11650,7 @@ object_types:
         type:
           type: named
           name: Int
+    foreign_keys: {}
   Track_set_input:
     description: "input type for updating data in table \"Track\""
     fields:
@@ -11296,6 +11702,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_stddev_fields:
     description: aggregate stddev on columns
     fields:
@@ -11341,6 +11748,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_stddev_order_by:
     description: "order by stddev() on columns of table \"Track\""
     fields:
@@ -11386,6 +11794,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_stddev_pop_fields:
     description: aggregate stddev_pop on columns
     fields:
@@ -11431,6 +11840,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_stddev_pop_order_by:
     description: "order by stddev_pop() on columns of table \"Track\""
     fields:
@@ -11476,6 +11886,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_stddev_samp_fields:
     description: aggregate stddev_samp on columns
     fields:
@@ -11521,6 +11932,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_stddev_samp_order_by:
     description: "order by stddev_samp() on columns of table \"Track\""
     fields:
@@ -11566,6 +11978,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_stream_cursor_input:
     description: "Streaming cursor of the table \"Track\""
     fields:
@@ -11581,6 +11994,7 @@ object_types:
           underlying_type:
             type: named
             name: cursor_ordering
+    foreign_keys: {}
   Track_stream_cursor_value_input:
     description: Initial value of the column from where the streaming should start
     fields:
@@ -11638,6 +12052,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_sum_fields:
     description: aggregate sum on columns
     fields:
@@ -11683,6 +12098,7 @@ object_types:
           underlying_type:
             type: named
             name: numeric
+    foreign_keys: {}
   Track_sum_order_by:
     description: "order by sum() on columns of table \"Track\""
     fields:
@@ -11728,6 +12144,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_updates:
     fields:
       _inc:
@@ -11749,6 +12166,7 @@ object_types:
         type:
           type: named
           name: Track_bool_exp
+    foreign_keys: {}
   Track_var_pop_fields:
     description: aggregate var_pop on columns
     fields:
@@ -11794,6 +12212,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_var_pop_order_by:
     description: "order by var_pop() on columns of table \"Track\""
     fields:
@@ -11839,6 +12258,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_var_samp_fields:
     description: aggregate var_samp on columns
     fields:
@@ -11884,6 +12304,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_var_samp_order_by:
     description: "order by var_samp() on columns of table \"Track\""
     fields:
@@ -11929,6 +12350,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   Track_variance_fields:
     description: aggregate variance on columns
     fields:
@@ -11974,6 +12396,7 @@ object_types:
           underlying_type:
             type: named
             name: Float
+    foreign_keys: {}
   Track_variance_order_by:
     description: "order by variance() on columns of table \"Track\""
     fields:
@@ -12019,6 +12442,7 @@ object_types:
           underlying_type:
             type: named
             name: order_by
+    foreign_keys: {}
   _AlbumQueryResponse:
     description: Response type for function Album
     fields:
@@ -12032,6 +12456,7 @@ object_types:
           element_type:
             type: named
             name: Album
+    foreign_keys: {}
   _Album_aggregateQueryResponse:
     description: Response type for function Album_aggregate
     fields:
@@ -12043,6 +12468,7 @@ object_types:
         type:
           type: named
           name: Album_aggregate
+    foreign_keys: {}
   _Album_by_pkQueryResponse:
     description: Response type for function Album_by_pk
     fields:
@@ -12056,6 +12482,7 @@ object_types:
           underlying_type:
             type: named
             name: Album
+    foreign_keys: {}
   _ArtistQueryResponse:
     description: Response type for function Artist
     fields:
@@ -12069,6 +12496,7 @@ object_types:
           element_type:
             type: named
             name: Artist
+    foreign_keys: {}
   _Artist_aggregateQueryResponse:
     description: Response type for function Artist_aggregate
     fields:
@@ -12080,6 +12508,7 @@ object_types:
         type:
           type: named
           name: Artist_aggregate
+    foreign_keys: {}
   _Artist_by_pkQueryResponse:
     description: Response type for function Artist_by_pk
     fields:
@@ -12093,6 +12522,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist
+    foreign_keys: {}
   _CustomerQueryResponse:
     description: Response type for function Customer
     fields:
@@ -12106,6 +12536,7 @@ object_types:
           element_type:
             type: named
             name: Customer
+    foreign_keys: {}
   _Customer_aggregateQueryResponse:
     description: Response type for function Customer_aggregate
     fields:
@@ -12117,6 +12548,7 @@ object_types:
         type:
           type: named
           name: Customer_aggregate
+    foreign_keys: {}
   _Customer_by_pkQueryResponse:
     description: Response type for function Customer_by_pk
     fields:
@@ -12130,6 +12562,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer
+    foreign_keys: {}
   _EmployeeQueryResponse:
     description: Response type for function Employee
     fields:
@@ -12143,6 +12576,7 @@ object_types:
           element_type:
             type: named
             name: Employee
+    foreign_keys: {}
   _Employee_aggregateQueryResponse:
     description: Response type for function Employee_aggregate
     fields:
@@ -12154,6 +12588,7 @@ object_types:
         type:
           type: named
           name: Employee_aggregate
+    foreign_keys: {}
   _Employee_by_pkQueryResponse:
     description: Response type for function Employee_by_pk
     fields:
@@ -12167,6 +12602,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee
+    foreign_keys: {}
   _GenreQueryResponse:
     description: Response type for function Genre
     fields:
@@ -12180,6 +12616,7 @@ object_types:
           element_type:
             type: named
             name: Genre
+    foreign_keys: {}
   _Genre_aggregateQueryResponse:
     description: Response type for function Genre_aggregate
     fields:
@@ -12191,6 +12628,7 @@ object_types:
         type:
           type: named
           name: Genre_aggregate
+    foreign_keys: {}
   _Genre_by_pkQueryResponse:
     description: Response type for function Genre_by_pk
     fields:
@@ -12204,6 +12642,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre
+    foreign_keys: {}
   _InvoiceLineQueryResponse:
     description: Response type for function InvoiceLine
     fields:
@@ -12217,6 +12656,7 @@ object_types:
           element_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   _InvoiceLine_aggregateQueryResponse:
     description: Response type for function InvoiceLine_aggregate
     fields:
@@ -12228,6 +12668,7 @@ object_types:
         type:
           type: named
           name: InvoiceLine_aggregate
+    foreign_keys: {}
   _InvoiceLine_by_pkQueryResponse:
     description: Response type for function InvoiceLine_by_pk
     fields:
@@ -12241,6 +12682,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   _InvoiceQueryResponse:
     description: Response type for function Invoice
     fields:
@@ -12254,6 +12696,7 @@ object_types:
           element_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   _Invoice_aggregateQueryResponse:
     description: Response type for function Invoice_aggregate
     fields:
@@ -12265,6 +12708,7 @@ object_types:
         type:
           type: named
           name: Invoice_aggregate
+    foreign_keys: {}
   _Invoice_by_pkQueryResponse:
     description: Response type for function Invoice_by_pk
     fields:
@@ -12278,6 +12722,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   _MediaTypeQueryResponse:
     description: Response type for function MediaType
     fields:
@@ -12291,6 +12736,7 @@ object_types:
           element_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   _MediaType_aggregateQueryResponse:
     description: Response type for function MediaType_aggregate
     fields:
@@ -12302,6 +12748,7 @@ object_types:
         type:
           type: named
           name: MediaType_aggregate
+    foreign_keys: {}
   _MediaType_by_pkQueryResponse:
     description: Response type for function MediaType_by_pk
     fields:
@@ -12315,6 +12762,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   _PlaylistQueryResponse:
     description: Response type for function Playlist
     fields:
@@ -12328,6 +12776,7 @@ object_types:
           element_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   _PlaylistTrackQueryResponse:
     description: Response type for function PlaylistTrack
     fields:
@@ -12341,6 +12790,7 @@ object_types:
           element_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   _PlaylistTrack_aggregateQueryResponse:
     description: Response type for function PlaylistTrack_aggregate
     fields:
@@ -12352,6 +12802,7 @@ object_types:
         type:
           type: named
           name: PlaylistTrack_aggregate
+    foreign_keys: {}
   _PlaylistTrack_by_pkQueryResponse:
     description: Response type for function PlaylistTrack_by_pk
     fields:
@@ -12365,6 +12816,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   _Playlist_aggregateQueryResponse:
     description: Response type for function Playlist_aggregate
     fields:
@@ -12376,6 +12828,7 @@ object_types:
         type:
           type: named
           name: Playlist_aggregate
+    foreign_keys: {}
   _Playlist_by_pkQueryResponse:
     description: Response type for function Playlist_by_pk
     fields:
@@ -12389,6 +12842,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   _TrackQueryResponse:
     description: Response type for function Track
     fields:
@@ -12402,6 +12856,7 @@ object_types:
           element_type:
             type: named
             name: Track
+    foreign_keys: {}
   _Track_aggregateQueryResponse:
     description: Response type for function Track_aggregate
     fields:
@@ -12413,6 +12868,7 @@ object_types:
         type:
           type: named
           name: Track_aggregate
+    foreign_keys: {}
   _Track_by_pkQueryResponse:
     description: Response type for function Track_by_pk
     fields:
@@ -12426,6 +12882,7 @@ object_types:
           underlying_type:
             type: named
             name: Track
+    foreign_keys: {}
   _delete_AlbumMutationResponse:
     description: Response type for procedure delete_Album
     fields:
@@ -12439,6 +12896,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_mutation_response
+    foreign_keys: {}
   _delete_Album_by_pkMutationResponse:
     description: Response type for procedure delete_Album_by_pk
     fields:
@@ -12452,6 +12910,7 @@ object_types:
           underlying_type:
             type: named
             name: Album
+    foreign_keys: {}
   _delete_ArtistMutationResponse:
     description: Response type for procedure delete_Artist
     fields:
@@ -12465,6 +12924,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_mutation_response
+    foreign_keys: {}
   _delete_Artist_by_pkMutationResponse:
     description: Response type for procedure delete_Artist_by_pk
     fields:
@@ -12478,6 +12938,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist
+    foreign_keys: {}
   _delete_CustomerMutationResponse:
     description: Response type for procedure delete_Customer
     fields:
@@ -12491,6 +12952,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_mutation_response
+    foreign_keys: {}
   _delete_Customer_by_pkMutationResponse:
     description: Response type for procedure delete_Customer_by_pk
     fields:
@@ -12504,6 +12966,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer
+    foreign_keys: {}
   _delete_EmployeeMutationResponse:
     description: Response type for procedure delete_Employee
     fields:
@@ -12517,6 +12980,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_mutation_response
+    foreign_keys: {}
   _delete_Employee_by_pkMutationResponse:
     description: Response type for procedure delete_Employee_by_pk
     fields:
@@ -12530,6 +12994,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee
+    foreign_keys: {}
   _delete_GenreMutationResponse:
     description: Response type for procedure delete_Genre
     fields:
@@ -12543,6 +13008,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_mutation_response
+    foreign_keys: {}
   _delete_Genre_by_pkMutationResponse:
     description: Response type for procedure delete_Genre_by_pk
     fields:
@@ -12556,6 +13022,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre
+    foreign_keys: {}
   _delete_InvoiceLineMutationResponse:
     description: Response type for procedure delete_InvoiceLine
     fields:
@@ -12569,6 +13036,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_mutation_response
+    foreign_keys: {}
   _delete_InvoiceLine_by_pkMutationResponse:
     description: Response type for procedure delete_InvoiceLine_by_pk
     fields:
@@ -12582,6 +13050,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   _delete_InvoiceMutationResponse:
     description: Response type for procedure delete_Invoice
     fields:
@@ -12595,6 +13064,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_mutation_response
+    foreign_keys: {}
   _delete_Invoice_by_pkMutationResponse:
     description: Response type for procedure delete_Invoice_by_pk
     fields:
@@ -12608,6 +13078,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   _delete_MediaTypeMutationResponse:
     description: Response type for procedure delete_MediaType
     fields:
@@ -12621,6 +13092,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_mutation_response
+    foreign_keys: {}
   _delete_MediaType_by_pkMutationResponse:
     description: Response type for procedure delete_MediaType_by_pk
     fields:
@@ -12634,6 +13106,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   _delete_PlaylistMutationResponse:
     description: Response type for procedure delete_Playlist
     fields:
@@ -12647,6 +13120,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_mutation_response
+    foreign_keys: {}
   _delete_PlaylistTrackMutationResponse:
     description: Response type for procedure delete_PlaylistTrack
     fields:
@@ -12660,6 +13134,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_mutation_response
+    foreign_keys: {}
   _delete_PlaylistTrack_by_pkMutationResponse:
     description: Response type for procedure delete_PlaylistTrack_by_pk
     fields:
@@ -12673,6 +13148,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   _delete_Playlist_by_pkMutationResponse:
     description: Response type for procedure delete_Playlist_by_pk
     fields:
@@ -12686,6 +13162,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   _delete_TrackMutationResponse:
     description: Response type for procedure delete_Track
     fields:
@@ -12699,6 +13176,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_mutation_response
+    foreign_keys: {}
   _delete_Track_by_pkMutationResponse:
     description: Response type for procedure delete_Track_by_pk
     fields:
@@ -12712,6 +13190,7 @@ object_types:
           underlying_type:
             type: named
             name: Track
+    foreign_keys: {}
   _insert_AlbumMutationResponse:
     description: Response type for procedure insert_Album
     fields:
@@ -12725,6 +13204,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_mutation_response
+    foreign_keys: {}
   _insert_Album_oneMutationResponse:
     description: Response type for procedure insert_Album_one
     fields:
@@ -12738,6 +13218,7 @@ object_types:
           underlying_type:
             type: named
             name: Album
+    foreign_keys: {}
   _insert_ArtistMutationResponse:
     description: Response type for procedure insert_Artist
     fields:
@@ -12751,6 +13232,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_mutation_response
+    foreign_keys: {}
   _insert_Artist_oneMutationResponse:
     description: Response type for procedure insert_Artist_one
     fields:
@@ -12764,6 +13246,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist
+    foreign_keys: {}
   _insert_CustomerMutationResponse:
     description: Response type for procedure insert_Customer
     fields:
@@ -12777,6 +13260,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_mutation_response
+    foreign_keys: {}
   _insert_Customer_oneMutationResponse:
     description: Response type for procedure insert_Customer_one
     fields:
@@ -12790,6 +13274,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer
+    foreign_keys: {}
   _insert_EmployeeMutationResponse:
     description: Response type for procedure insert_Employee
     fields:
@@ -12803,6 +13288,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_mutation_response
+    foreign_keys: {}
   _insert_Employee_oneMutationResponse:
     description: Response type for procedure insert_Employee_one
     fields:
@@ -12816,6 +13302,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee
+    foreign_keys: {}
   _insert_GenreMutationResponse:
     description: Response type for procedure insert_Genre
     fields:
@@ -12829,6 +13316,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_mutation_response
+    foreign_keys: {}
   _insert_Genre_oneMutationResponse:
     description: Response type for procedure insert_Genre_one
     fields:
@@ -12842,6 +13330,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre
+    foreign_keys: {}
   _insert_InvoiceLineMutationResponse:
     description: Response type for procedure insert_InvoiceLine
     fields:
@@ -12855,6 +13344,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_mutation_response
+    foreign_keys: {}
   _insert_InvoiceLine_oneMutationResponse:
     description: Response type for procedure insert_InvoiceLine_one
     fields:
@@ -12868,6 +13358,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   _insert_InvoiceMutationResponse:
     description: Response type for procedure insert_Invoice
     fields:
@@ -12881,6 +13372,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_mutation_response
+    foreign_keys: {}
   _insert_Invoice_oneMutationResponse:
     description: Response type for procedure insert_Invoice_one
     fields:
@@ -12894,6 +13386,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   _insert_MediaTypeMutationResponse:
     description: Response type for procedure insert_MediaType
     fields:
@@ -12907,6 +13400,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_mutation_response
+    foreign_keys: {}
   _insert_MediaType_oneMutationResponse:
     description: Response type for procedure insert_MediaType_one
     fields:
@@ -12920,6 +13414,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   _insert_PlaylistMutationResponse:
     description: Response type for procedure insert_Playlist
     fields:
@@ -12933,6 +13428,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_mutation_response
+    foreign_keys: {}
   _insert_PlaylistTrackMutationResponse:
     description: Response type for procedure insert_PlaylistTrack
     fields:
@@ -12946,6 +13442,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_mutation_response
+    foreign_keys: {}
   _insert_PlaylistTrack_oneMutationResponse:
     description: Response type for procedure insert_PlaylistTrack_one
     fields:
@@ -12959,6 +13456,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   _insert_Playlist_oneMutationResponse:
     description: Response type for procedure insert_Playlist_one
     fields:
@@ -12972,6 +13470,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   _insert_TrackMutationResponse:
     description: Response type for procedure insert_Track
     fields:
@@ -12985,6 +13484,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_mutation_response
+    foreign_keys: {}
   _insert_Track_oneMutationResponse:
     description: Response type for procedure insert_Track_one
     fields:
@@ -12998,6 +13498,7 @@ object_types:
           underlying_type:
             type: named
             name: Track
+    foreign_keys: {}
   _update_AlbumMutationResponse:
     description: Response type for procedure update_Album
     fields:
@@ -13011,6 +13512,7 @@ object_types:
           underlying_type:
             type: named
             name: Album_mutation_response
+    foreign_keys: {}
   _update_Album_by_pkMutationResponse:
     description: Response type for procedure update_Album_by_pk
     fields:
@@ -13024,6 +13526,7 @@ object_types:
           underlying_type:
             type: named
             name: Album
+    foreign_keys: {}
   _update_Album_manyMutationResponse:
     description: Response type for procedure update_Album_many
     fields:
@@ -13041,6 +13544,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Album_mutation_response
+    foreign_keys: {}
   _update_ArtistMutationResponse:
     description: Response type for procedure update_Artist
     fields:
@@ -13054,6 +13558,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist_mutation_response
+    foreign_keys: {}
   _update_Artist_by_pkMutationResponse:
     description: Response type for procedure update_Artist_by_pk
     fields:
@@ -13067,6 +13572,7 @@ object_types:
           underlying_type:
             type: named
             name: Artist
+    foreign_keys: {}
   _update_Artist_manyMutationResponse:
     description: Response type for procedure update_Artist_many
     fields:
@@ -13084,6 +13590,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Artist_mutation_response
+    foreign_keys: {}
   _update_CustomerMutationResponse:
     description: Response type for procedure update_Customer
     fields:
@@ -13097,6 +13604,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer_mutation_response
+    foreign_keys: {}
   _update_Customer_by_pkMutationResponse:
     description: Response type for procedure update_Customer_by_pk
     fields:
@@ -13110,6 +13618,7 @@ object_types:
           underlying_type:
             type: named
             name: Customer
+    foreign_keys: {}
   _update_Customer_manyMutationResponse:
     description: Response type for procedure update_Customer_many
     fields:
@@ -13127,6 +13636,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Customer_mutation_response
+    foreign_keys: {}
   _update_EmployeeMutationResponse:
     description: Response type for procedure update_Employee
     fields:
@@ -13140,6 +13650,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee_mutation_response
+    foreign_keys: {}
   _update_Employee_by_pkMutationResponse:
     description: Response type for procedure update_Employee_by_pk
     fields:
@@ -13153,6 +13664,7 @@ object_types:
           underlying_type:
             type: named
             name: Employee
+    foreign_keys: {}
   _update_Employee_manyMutationResponse:
     description: Response type for procedure update_Employee_many
     fields:
@@ -13170,6 +13682,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Employee_mutation_response
+    foreign_keys: {}
   _update_GenreMutationResponse:
     description: Response type for procedure update_Genre
     fields:
@@ -13183,6 +13696,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre_mutation_response
+    foreign_keys: {}
   _update_Genre_by_pkMutationResponse:
     description: Response type for procedure update_Genre_by_pk
     fields:
@@ -13196,6 +13710,7 @@ object_types:
           underlying_type:
             type: named
             name: Genre
+    foreign_keys: {}
   _update_Genre_manyMutationResponse:
     description: Response type for procedure update_Genre_many
     fields:
@@ -13213,6 +13728,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Genre_mutation_response
+    foreign_keys: {}
   _update_InvoiceLineMutationResponse:
     description: Response type for procedure update_InvoiceLine
     fields:
@@ -13226,6 +13742,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine_mutation_response
+    foreign_keys: {}
   _update_InvoiceLine_by_pkMutationResponse:
     description: Response type for procedure update_InvoiceLine_by_pk
     fields:
@@ -13239,6 +13756,7 @@ object_types:
           underlying_type:
             type: named
             name: InvoiceLine
+    foreign_keys: {}
   _update_InvoiceLine_manyMutationResponse:
     description: Response type for procedure update_InvoiceLine_many
     fields:
@@ -13256,6 +13774,7 @@ object_types:
               underlying_type:
                 type: named
                 name: InvoiceLine_mutation_response
+    foreign_keys: {}
   _update_InvoiceMutationResponse:
     description: Response type for procedure update_Invoice
     fields:
@@ -13269,6 +13788,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice_mutation_response
+    foreign_keys: {}
   _update_Invoice_by_pkMutationResponse:
     description: Response type for procedure update_Invoice_by_pk
     fields:
@@ -13282,6 +13802,7 @@ object_types:
           underlying_type:
             type: named
             name: Invoice
+    foreign_keys: {}
   _update_Invoice_manyMutationResponse:
     description: Response type for procedure update_Invoice_many
     fields:
@@ -13299,6 +13820,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Invoice_mutation_response
+    foreign_keys: {}
   _update_MediaTypeMutationResponse:
     description: Response type for procedure update_MediaType
     fields:
@@ -13312,6 +13834,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType_mutation_response
+    foreign_keys: {}
   _update_MediaType_by_pkMutationResponse:
     description: Response type for procedure update_MediaType_by_pk
     fields:
@@ -13325,6 +13848,7 @@ object_types:
           underlying_type:
             type: named
             name: MediaType
+    foreign_keys: {}
   _update_MediaType_manyMutationResponse:
     description: Response type for procedure update_MediaType_many
     fields:
@@ -13342,6 +13866,7 @@ object_types:
               underlying_type:
                 type: named
                 name: MediaType_mutation_response
+    foreign_keys: {}
   _update_PlaylistMutationResponse:
     description: Response type for procedure update_Playlist
     fields:
@@ -13355,6 +13880,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist_mutation_response
+    foreign_keys: {}
   _update_PlaylistTrackMutationResponse:
     description: Response type for procedure update_PlaylistTrack
     fields:
@@ -13368,6 +13894,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack_mutation_response
+    foreign_keys: {}
   _update_PlaylistTrack_by_pkMutationResponse:
     description: Response type for procedure update_PlaylistTrack_by_pk
     fields:
@@ -13381,6 +13908,7 @@ object_types:
           underlying_type:
             type: named
             name: PlaylistTrack
+    foreign_keys: {}
   _update_PlaylistTrack_manyMutationResponse:
     description: Response type for procedure update_PlaylistTrack_many
     fields:
@@ -13398,6 +13926,7 @@ object_types:
               underlying_type:
                 type: named
                 name: PlaylistTrack_mutation_response
+    foreign_keys: {}
   _update_Playlist_by_pkMutationResponse:
     description: Response type for procedure update_Playlist_by_pk
     fields:
@@ -13411,6 +13940,7 @@ object_types:
           underlying_type:
             type: named
             name: Playlist
+    foreign_keys: {}
   _update_Playlist_manyMutationResponse:
     description: Response type for procedure update_Playlist_many
     fields:
@@ -13428,6 +13958,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Playlist_mutation_response
+    foreign_keys: {}
   _update_TrackMutationResponse:
     description: Response type for procedure update_Track
     fields:
@@ -13441,6 +13972,7 @@ object_types:
           underlying_type:
             type: named
             name: Track_mutation_response
+    foreign_keys: {}
   _update_Track_by_pkMutationResponse:
     description: Response type for procedure update_Track_by_pk
     fields:
@@ -13454,6 +13986,7 @@ object_types:
           underlying_type:
             type: named
             name: Track
+    foreign_keys: {}
   _update_Track_manyMutationResponse:
     description: Response type for procedure update_Track_many
     fields:
@@ -13471,6 +14004,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Track_mutation_response
+    foreign_keys: {}
   numeric_comparison_exp:
     description: "Boolean expression to compare columns of type \"numeric\". All fields are combined with logical 'AND'."
     fields:
@@ -13532,6 +14066,7 @@ object_types:
             element_type:
               type: named
               name: numeric
+    foreign_keys: {}
   subscription_root:
     fields:
       Album:
@@ -15001,6 +15536,7 @@ object_types:
               underlying_type:
                 type: named
                 name: Track_bool_exp
+    foreign_keys: {}
   timestamp_comparison_exp:
     description: "Boolean expression to compare columns of type \"timestamp\". All fields are combined with logical 'AND'."
     fields:
@@ -15062,6 +15598,7 @@ object_types:
             element_type:
               type: named
               name: timestamp
+    foreign_keys: {}
 collections: []
 functions:
   - name: Album
@@ -17888,3 +18425,5 @@ procedures:
     result_type:
       type: named
       name: _update_Track_manyMutationResponse
+capabilities: ~
+request_arguments: ~

--- a/crates/ndc-graphql/tests/snapshots/query_builder__config-3 NDC Schema.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__config-3 NDC Schema.snap
@@ -18426,4 +18426,21 @@ procedures:
       type: named
       name: _update_Track_manyMutationResponse
 capabilities: ~
-request_arguments: ~
+request_arguments:
+  query_arguments:
+    headers:
+      description: Headers to be merged into original request headers of graphql requests
+      type:
+        type: nullable
+        underlying_type:
+          type: named
+          name: _HeaderMap
+  mutation_arguments:
+    headers:
+      description: Headers to be merged into original request headers of graphql requests
+      type:
+        type: nullable
+        underlying_type:
+          type: named
+          name: _HeaderMap
+  relational_query_arguments: {}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,34 @@
+check: format-check build lint test
+
+build:
+  cargo build --all-targets --all-features
+
+# re-build on code changes, and run the reference agent each time a build is
+# successful
+dev:
+  mkdir -p ./tmp/empty
+  cargo watch \
+    -x test \
+    -x 'run --bin ndc_hub_example \
+    -- serve --configuration ./tmp/empty \
+    --otlp-endpoint http://localhost:4317'
+
+format:
+  cargo fmt --all
+  ! command -v nix > /dev/null || nix fmt
+  ! command -v prettier > /dev/null || prettier --write .
+
+format-check:
+  cargo fmt --all --check
+  ! command -v nix > /dev/null || nix fmt -- --check .
+  ! command -v prettier > /dev/null || prettier --check .
+
+lint:
+  cargo clippy --all-targets --all-features
+  cargo machete --with-metadata
+
+lint-apply:
+  cargo clippy --fix --all-targets --all-features
+
+test:
+  cargo test --all-targets --all-features

--- a/justfile
+++ b/justfile
@@ -2,25 +2,13 @@ check: format-check build lint test
 
 build:
   cargo build --all-targets --all-features
-
-# re-build on code changes, and run the reference agent each time a build is
-# successful
-dev:
-  mkdir -p ./tmp/empty
-  cargo watch \
-    -x test \
-    -x 'run --bin ndc_hub_example \
-    -- serve --configuration ./tmp/empty \
-    --otlp-endpoint http://localhost:4317'
-
+  
 format:
   cargo fmt --all
-  ! command -v nix > /dev/null || nix fmt
   ! command -v prettier > /dev/null || prettier --write .
 
 format-check:
   cargo fmt --all --check
-  ! command -v nix > /dev/null || nix fmt -- --check .
   ! command -v prettier > /dev/null || prettier --check .
 
 lint:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.89.0"
+profile = "default"  # see https://rust-lang.github.io/rustup/concepts/profiles.html
+components = ["rust-analyzer", "rust-src"]  # see https://rust-lang.github.io/rustup/concepts/components.html


### PR DESCRIPTION
### Forward Headers from Pre-NDC Request Plugin
 
You can use a [Pre-NDC Request Plugin](https://hasura.io/docs/3.0/plugins/introduction#pre-ndc-request-plugin) to modify the request, and add dynamic headers in runtime via `request_arguments.headers` field, which is a string map. Those headers will be merged into the HTTP request headers before being sent to external services.

> See the full example at [Pre-NDC Request Plugin Request](https://hasura.io/docs/3.0/plugins/introduction#example-configuration)
 
```json
{
  // ...
  "ndcRequest": {
    // ...
    "request_arguments": {
        "headers": {
            "Authorization": "Bearer <token>",
            "X-Custom-Header": "foo"
        }
    }
  }
}
```

### Other changes

- Upgrade ndc-spec v0.2.10
- Upgrade Rust SDK and dependencies