### PR TITLE
ci: fix failed release pipeline at the artifact download job

### DIFF
--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -13,6 +13,9 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # Fix the artifact download failure
+  # Reference: https://github.com/actions/download-artifact/issues/377#issuecomment-2651196178
+  DOCKER_BUILD_RECORD_UPLOAD: "false"
 
 jobs:
   build-and-push-image:
@@ -153,7 +156,7 @@ jobs:
 
       - uses: actions/checkout@v5
           
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: release/artifacts
           merge-multiple: true


### PR DESCRIPTION
This pull request updates the deployment workflow to address an artifact download issue and to use the latest version of an action. The most important changes are:

**Workflow Reliability Improvements:**

* Added the `DOCKER_BUILD_RECORD_UPLOAD` environment variable set to `"false"` to work around a known artifact download failure in GitHub Actions.

**Dependency Updates:**

* Upgraded the `actions/download-artifact` action from version 4 to version 5 to ensure compatibility and benefit from recent fixes.