### PR TITLE
add support for custom CA's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Breaking: GraphQL `interface` and `union` output types are now lowered into tagged-variant NDC object types by default.
+  - Lowered object types include `__typename` and one nullable field per concrete type (`on_<ConcreteType>`).
+  - Query generation translates tagged variant selections to GraphQL inline fragments (`... on <ConcreteType>`).
+  - Validation now fails early with clear errors for unsupported polymorphic schemas (for example unions/interfaces without concrete object members, or unresolved type references).
+
 ## [0.3.0]
 
 - Upgrade ndc-spec v0.2.10 and ndc-rust-sdk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1]
+
+- Add support for custom CA certificates and allow skipping TLS verification entirely
+
 ## [0.3.0]
 
 - Upgrade ndc-spec v0.2.10 and ndc-rust-sdk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,9 +353,11 @@ dependencies = [
  "graphql_client",
  "ndc-models",
  "reqwest",
+ "rustls-pemfile",
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -2003,6 +2005,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.3.1"
+version = "0.3.0"
 dependencies = [
  "glob-match",
  "graphql-parser",
@@ -357,6 +357,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -1304,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-graphql"
-version = "0.3.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "common",
@@ -1323,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-graphql-cli"
-version = "0.3.1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "glob-match",
  "graphql-parser",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-graphql"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "common",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-graphql-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/ndc-graphql", "crates/ndc-graphql-cli", "crates/common"]
 resolver = "2"
 
-package.version = "0.3.1"
+package.version = "0.3.0"
 package.edition = "2021"
 package.license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/ndc-graphql", "crates/ndc-graphql-cli", "crates/common"]
 resolver = "2"
 
-package.version = "0.3.0"
+package.version = "0.3.1"
 package.edition = "2021"
 package.license = "Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Below, you'll find a matrix of all supported features for the GraphQL connector:
 | Header Passthrough      | ✅         | Entire headers can be forwarded                              |
 | Request-level Arguments | ✅         | Support dynamic headers from the from Pre-NDC Request Plugin |
 | Subscriptions           | ❌         |                                                              |
-| Unions                  | ❌         | Can be brought in via scalar types                           |
-| Interfaces              | ❌         |                                                              |
+| Unions                  | ✅         | Lowered to tagged-variant object types (`__typename`, `on_<Type>`) |
+| Interfaces              | ✅         | Lowered to tagged-variant object types (`__typename`, `on_<Type>`) |
 | Relay API               | ❌         |                                                              |
 | Directives              | ❌         | @cached, Apollo directives                                   |
 
@@ -57,6 +57,10 @@ Below, you'll find a matrix of all supported features for the GraphQL connector:
 * Error formatting
   - The format of errors from the connector does not currently match V2 error formatting
   - No "partial error" or "multiple errors" responses
+* Polymorphic output lowering
+  - GraphQL `interface` and `union` outputs are lowered into synthetic object types in NDC metadata.
+  - Lowered object types expose `__typename` plus one nullable tagged field per concrete type: `on_<ConcreteType>`.
+  - When lowering is not possible (for example no concrete object members), config/schema validation fails with a targeted error.
 * Pattern matching in request header forwarding configuration
   - This uses simple glob patterns
   - More advanced matching and extraction is not currently supported

--- a/README.md
+++ b/README.md
@@ -90,3 +90,18 @@ You can use a [Pre-NDC Request Plugin](https://hasura.io/docs/3.0/plugins/introd
   }
 }
 ```
+
+### TLS/SSL Configuration
+
+The connector uses `rustls` for TLS which does not automatically pick up system certificate stores. For self-hosted deployments using organization-signed certificates, you can configure custom CA certificates or disable TLS verification via environment variables.
+
+| Variable | Description |
+|----------|-------------|
+| `GRAPHQL_CA_CERT_FILE` | Path to a single PEM-encoded CA certificate file |
+| `GRAPHQL_CA_CERT_DIR` | Directory containing PEM-encoded CA certificates (`.pem`, `.crt`, `.cer`) |
+| `GRAPHQL_INSECURE_SKIP_TLS_VERIFY` | Set to `true` or `1` to disable TLS verification |
+
+**Notes:**
+- `GRAPHQL_CA_CERT_FILE` and `GRAPHQL_CA_CERT_DIR` can be used together (certificates are combined)
+- `GRAPHQL_INSECURE_SKIP_TLS_VERIFY` takes precedence and skips all CA cert logic when enabled
+- **Warning:** Disabling TLS verification is insecure and should only be used for development/testing

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -13,4 +13,5 @@ rustls-pemfile = "2"
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = "1"
 tracing = { workspace = true }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -9,6 +9,8 @@ graphql_client = { workspace = true }
 graphql-parser = { workspace = true }
 ndc-models = { workspace = true }
 reqwest = { workspace = true }
+rustls-pemfile = "2"
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tracing = { workspace = true }

--- a/crates/common/src/client.rs
+++ b/crates/common/src/client.rs
@@ -2,19 +2,101 @@ use crate::config::ConnectionConfig;
 use glob_match::glob_match;
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 use serde::Serialize;
-use std::{collections::BTreeMap, error::Error, fmt::Debug};
+use std::{
+    collections::BTreeMap,
+    env,
+    error::Error,
+    fmt::Debug,
+    fs::{self, File},
+    io::BufReader,
+    path::Path,
+};
+
+const CA_CERT_FILE_ENV: &str = "GRAPHQL_CA_CERT_FILE";
+const CA_CERT_DIR_ENV: &str = "GRAPHQL_CA_CERT_DIR";
+const INSECURE_SKIP_VERIFY_ENV: &str = "GRAPHQL_INSECURE_SKIP_TLS_VERIFY";
+
+fn load_certs_from_file(path: &Path) -> Result<Vec<reqwest::Certificate>, Box<dyn Error>> {
+    if !path.is_file() {
+        return Err(format!("{} is not a file", path.display()).into());
+    }
+    tracing::info!("Loading CA certs from file: {}", path.display());
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let certs = rustls_pemfile::certs(&mut reader).collect::<Result<Vec<_>, _>>()?;
+    let certs: Vec<_> = certs
+        .into_iter()
+        .map(|cert| reqwest::Certificate::from_der(cert.as_ref()).map_err(Into::into))
+        .collect::<Result<_, Box<dyn Error>>>()?;
+    tracing::info!("Loaded {} cert(s) from {}", certs.len(), path.display());
+    Ok(certs)
+}
+
+fn load_certs_from_dir(dir_path: &str) -> Result<Vec<reqwest::Certificate>, Box<dyn Error>> {
+    let path = Path::new(dir_path);
+    if !path.is_dir() {
+        return Err(format!("{} is not a directory", dir_path).into());
+    }
+    tracing::info!("Loading CA certs from directory: {}", dir_path);
+
+    let mut all_certs = Vec::new();
+    for entry in fs::read_dir(path)?.flatten() {
+        let file_path = entry.path();
+        let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if !matches!(ext.to_lowercase().as_str(), "pem" | "crt" | "cer") || !file_path.is_file() {
+            continue;
+        }
+        match load_certs_from_file(&file_path) {
+            Ok(certs) => all_certs.extend(certs),
+            Err(e) => tracing::warn!("Failed to load {}: {}", file_path.display(), e),
+        }
+    }
+
+    if all_certs.is_empty() {
+        return Err(format!("No valid certificates found in {}", dir_path).into());
+    }
+    tracing::info!(
+        "Loaded {} total CA cert(s) from {}",
+        all_certs.len(),
+        dir_path
+    );
+    Ok(all_certs)
+}
 
 pub fn get_http_client(
     _connection_config: &ConnectionConfig,
 ) -> Result<reqwest::Client, Box<dyn std::error::Error>> {
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    let mut builder = reqwest::Client::builder().default_headers(headers);
 
-    let client = reqwest::Client::builder()
-        .default_headers(headers)
-        .build()?;
+    // Insecure mode: skip all TLS verification, ignore CA cert settings
+    let insecure = env::var(INSECURE_SKIP_VERIFY_ENV)
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or(false);
+    if insecure {
+        tracing::warn!(
+            "TLS verification DISABLED via {} - insecure!",
+            INSECURE_SKIP_VERIFY_ENV
+        );
+        return Ok(builder.danger_accept_invalid_certs(true).build()?);
+    }
 
-    Ok(client)
+    // Load certs from file (if set)
+    if let Ok(cert_file) = env::var(CA_CERT_FILE_ENV) {
+        for cert in load_certs_from_file(Path::new(&cert_file))? {
+            builder = builder.add_root_certificate(cert);
+        }
+    }
+
+    // Load certs from directory (if set) - can be used together with file
+    if let Ok(cert_dir) = env::var(CA_CERT_DIR_ENV) {
+        for cert in load_certs_from_dir(&cert_dir)? {
+            builder = builder.add_root_certificate(cert);
+        }
+    }
+
+    Ok(builder.build()?)
 }
 
 pub async fn execute_graphql<T: serde::de::DeserializeOwned>(

--- a/crates/common/src/client.rs
+++ b/crates/common/src/client.rs
@@ -11,6 +11,116 @@ use std::{
     io::BufReader,
     path::Path,
 };
+use thiserror::Error;
+
+/// Errors that can occur when executing a GraphQL request against an upstream server.
+#[derive(Debug, Error)]
+pub enum GraphQLClientError {
+    /// Network/connection error (timeout, DNS, TLS, connection refused, etc.)
+    #[error("Failed to connect to upstream GraphQL server: {message}")]
+    NetworkError {
+        message: String,
+        endpoint: String,
+        #[source]
+        source: Option<reqwest::Error>,
+    },
+    /// Upstream server returned a non-2xx HTTP status code
+    #[error("{message}")]
+    HttpError {
+        status_code: u16,
+        message: String,
+        body: String,
+        endpoint: String,
+    },
+    /// Failed to parse JSON response from upstream
+    #[error("Failed to parse upstream response: {message}")]
+    ResponseParseError {
+        message: String,
+        body: String,
+        endpoint: String,
+    },
+}
+
+impl GraphQLClientError {
+    /// Returns a human-readable error message based on the HTTP status code
+    fn http_error_message(status_code: u16) -> &'static str {
+        match status_code {
+            400 => "Upstream server rejected the request",
+            401 => "Upstream server authentication failed",
+            403 => "Upstream server access forbidden",
+            404 => "Upstream GraphQL endpoint not found",
+            405 => "HTTP method not allowed by upstream server",
+            408 => "Upstream server request timeout",
+            429 => "Upstream server rate limit exceeded",
+            500 => "Upstream server internal error",
+            502 => "Upstream server bad gateway",
+            503 => "Upstream server temporarily unavailable",
+            504 => "Upstream server gateway timeout",
+            _ if (400..500).contains(&status_code) => "Upstream server client error",
+            _ if (500..).contains(&status_code) => "Upstream server error",
+            _ => "Upstream server returned unexpected status",
+        }
+    }
+
+    /// Returns the upstream HTTP status code if this is an HTTP error
+    pub fn status_code(&self) -> Option<u16> {
+        match self {
+            Self::HttpError { status_code, .. } => Some(*status_code),
+            _ => None,
+        }
+    }
+
+    /// Returns the endpoint that was called
+    pub fn endpoint(&self) -> &str {
+        match self {
+            Self::NetworkError { endpoint, .. }
+            | Self::HttpError { endpoint, .. }
+            | Self::ResponseParseError { endpoint, .. } => endpoint,
+        }
+    }
+
+    /// Returns the response body if available
+    pub fn body(&self) -> Option<&str> {
+        match self {
+            Self::HttpError { body, .. } | Self::ResponseParseError { body, .. } => Some(body),
+            Self::NetworkError { .. } => None,
+        }
+    }
+
+    /// Converts the error to a JSON value suitable for error details
+    pub fn to_details(&self) -> serde_json::Value {
+        match self {
+            Self::NetworkError {
+                message, endpoint, ..
+            } => serde_json::json!({
+                "error_type": "network_error",
+                "endpoint": endpoint,
+                "message": message,
+            }),
+            Self::HttpError {
+                status_code,
+                body,
+                endpoint,
+                ..
+            } => serde_json::json!({
+                "error_type": "http_error",
+                "upstream_status_code": status_code,
+                "upstream_body": body,
+                "endpoint": endpoint,
+            }),
+            Self::ResponseParseError {
+                message,
+                body,
+                endpoint,
+            } => serde_json::json!({
+                "error_type": "response_parse_error",
+                "endpoint": endpoint,
+                "message": message,
+                "body": body,
+            }),
+        }
+    }
+}
 
 const CA_CERT_FILE_ENV: &str = "GRAPHQL_CA_CERT_FILE";
 const CA_CERT_DIR_ENV: &str = "GRAPHQL_CA_CERT_DIR";
@@ -106,7 +216,7 @@ pub async fn execute_graphql<T: serde::de::DeserializeOwned>(
     headers: &BTreeMap<String, String>,
     client: &reqwest::Client,
     return_headers: &Vec<String>,
-) -> Result<(BTreeMap<String, String>, graphql_client::Response<T>), Box<dyn Error>> {
+) -> Result<(BTreeMap<String, String>, graphql_client::Response<T>), GraphQLClientError> {
     let mut request = client.post(endpoint);
 
     for (header_name, header_value) in headers {
@@ -117,8 +227,25 @@ pub async fn execute_graphql<T: serde::de::DeserializeOwned>(
 
     let request = request.json(&request_body);
 
-    let response = request.send().await?;
-    let headers = response
+    let response = match request.send().await {
+        Ok(resp) => resp,
+        Err(err) => {
+            let message = err.to_string();
+            tracing::error!(
+                endpoint = %endpoint,
+                error = %err,
+                "Failed to connect to upstream GraphQL server"
+            );
+            return Err(GraphQLClientError::NetworkError {
+                message,
+                endpoint: endpoint.to_string(),
+                source: Some(err),
+            });
+        }
+    };
+
+    // Extract headers before consuming the response
+    let response_headers: BTreeMap<String, String> = response
         .headers()
         .iter()
         .filter_map(|(name, value)| {
@@ -134,13 +261,64 @@ pub async fn execute_graphql<T: serde::de::DeserializeOwned>(
         })
         .collect();
 
-    if response.error_for_status_ref().is_err() {
-        return Err(response.text().await?.into());
+    // Extract status code before consuming the response
+    let status_code = response.status().as_u16();
+
+    // Check for HTTP errors
+    if !response.status().is_success() {
+        let body = response.text().await.unwrap_or_default();
+        let message = GraphQLClientError::http_error_message(status_code);
+
+        tracing::error!(
+            endpoint = %endpoint,
+            upstream_status = status_code,
+            upstream_body = %body,
+            "Upstream GraphQL server returned error"
+        );
+
+        return Err(GraphQLClientError::HttpError {
+            status_code,
+            message: message.to_string(),
+            body,
+            endpoint: endpoint.to_string(),
+        });
     }
 
-    let response: graphql_client::Response<T> = response.json().await?;
+    // Parse the JSON response
+    let body_text = match response.text().await {
+        Ok(text) => text,
+        Err(err) => {
+            tracing::error!(
+                endpoint = %endpoint,
+                error = %err,
+                "Failed to read response body from upstream"
+            );
+            return Err(GraphQLClientError::NetworkError {
+                message: format!("Failed to read response body: {err}"),
+                endpoint: endpoint.to_string(),
+                source: Some(err),
+            });
+        }
+    };
 
-    Ok((headers, response))
+    let parsed_response: graphql_client::Response<T> = match serde_json::from_str(&body_text) {
+        Ok(resp) => resp,
+        Err(err) => {
+            tracing::error!(
+                endpoint = %endpoint,
+                error = %err,
+                body = %body_text,
+                "Failed to parse JSON response from upstream"
+            );
+            return Err(GraphQLClientError::ResponseParseError {
+                message: err.to_string(),
+                body: body_text,
+                endpoint: endpoint.to_string(),
+            });
+        }
+    };
+
+    Ok((response_headers, parsed_response))
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/common/src/config/schema.rs
+++ b/crates/common/src/config/schema.rs
@@ -1,7 +1,10 @@
 use crate::config::{RequestConfig, ResponseConfig};
 use graphql_parser::schema;
 use ndc_models::{ArgumentName, FieldName, FunctionName, ProcedureName, ScalarTypeName, TypeName};
-use std::{collections::BTreeMap, fmt::Display};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Display,
+};
 
 #[derive(Debug, Clone)]
 pub struct SchemaDefinition {
@@ -30,19 +33,18 @@ impl SchemaDefinition {
             .ok_or(SchemaDefinitionError::MissingSchemaType)?;
 
         // note: if there are duplicate definitions, the last one will stick.
-        let definitions: BTreeMap<TypeName, TypeDef> = schema_document
-            .definitions
-            .iter()
-            .filter_map(|definition| match definition {
-                schema::Definition::SchemaDefinition(_) => None,
-                schema::Definition::DirectiveDefinition(_) => None,
-                schema::Definition::TypeExtension(_) => None,
+        let mut definitions: BTreeMap<TypeName, TypeDef> = BTreeMap::new();
+        let mut object_implements: Vec<(TypeName, Vec<TypeName>)> = vec![];
+
+        for definition in &schema_document.definitions {
+            let (type_name, type_def) = match definition {
+                schema::Definition::SchemaDefinition(_)
+                | schema::Definition::DirectiveDefinition(_)
+                | schema::Definition::TypeExtension(_) => continue,
                 schema::Definition::TypeDefinition(type_definition) => match type_definition {
-                    schema::TypeDefinition::Union(_) => None,
-                    schema::TypeDefinition::Interface(_) => None,
-                    schema::TypeDefinition::Scalar(scalar) => Some(TypeDef::new_scalar(scalar)),
+                    schema::TypeDefinition::Scalar(scalar) => TypeDef::new_scalar(scalar),
                     schema::TypeDefinition::Object(object) => {
-                        // skip query, mutation, subscription types
+                        // skip query, mutation, subscription root types
                         if schema_definition
                             .query
                             .as_ref()
@@ -56,26 +58,62 @@ impl SchemaDefinition {
                                 .as_ref()
                                 .is_some_and(|mutation_type| mutation_type == &object.name)
                         {
-                            None
-                        } else {
-                            Some(TypeDef::new_object(object))
+                            continue;
                         }
+
+                        let (name, def, implements_interfaces) = TypeDef::new_object(object);
+                        object_implements.push((name.clone(), implements_interfaces));
+                        (name, def)
                     }
                     schema::TypeDefinition::Enum(enum_definition) => {
-                        Some(TypeDef::new_enum(enum_definition))
+                        TypeDef::new_enum(enum_definition)
                     }
                     schema::TypeDefinition::InputObject(input_object) => {
-                        Some(TypeDef::new_input_object(input_object))
+                        TypeDef::new_input_object(input_object)
                     }
+                    schema::TypeDefinition::Interface(interface) => {
+                        TypeDef::new_interface(interface)
+                    }
+                    schema::TypeDefinition::Union(union) => TypeDef::new_union(union),
                 },
-            })
-            .collect();
+            };
+
+            definitions.insert(type_name, type_def);
+        }
+
+        for (object_name, interfaces) in object_implements {
+            for interface_name in interfaces {
+                if let Some(TypeDef::Interface { possible_types, .. }) =
+                    definitions.get_mut(&interface_name)
+                {
+                    possible_types.insert(object_name.clone());
+                }
+            }
+        }
 
         if definitions.contains_key(request_config.headers_type_name.inner()) {
             return Err(SchemaDefinitionError::HeaderTypeNameConflict(
                 request_config.headers_type_name.to_owned(),
             ));
         }
+
+        let root_type_names: BTreeSet<TypeName> = vec![
+            schema_definition
+                .query
+                .as_ref()
+                .map(|name| name.to_owned().into()),
+            schema_definition
+                .mutation
+                .as_ref()
+                .map(|name| name.to_owned().into()),
+            schema_definition
+                .subscription
+                .as_ref()
+                .map(|name| name.to_owned().into()),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
 
         let query_type = schema_document
             .definitions
@@ -166,6 +204,13 @@ impl SchemaDefinition {
             }
         }
 
+        validate_definition_type_references(
+            &definitions,
+            &query_fields,
+            &mutation_fields,
+            &root_type_names,
+        )?;
+
         Ok(Self {
             query_fields,
             query_type_name: schema_definition.query.to_owned().map(Into::into),
@@ -212,6 +257,15 @@ pub enum TypeDef {
         fields: BTreeMap<FieldName, ObjectFieldDefinition>,
         description: Option<String>,
     },
+    Interface {
+        fields: BTreeMap<FieldName, ObjectFieldDefinition>,
+        possible_types: BTreeSet<TypeName>,
+        description: Option<String>,
+    },
+    Union {
+        members: BTreeSet<TypeName>,
+        description: Option<String>,
+    },
     InputObject {
         fields: BTreeMap<FieldName, InputObjectFieldDefinition>,
         description: Option<String>,
@@ -240,7 +294,15 @@ impl TypeDef {
             },
         )
     }
-    fn new_object(object_definition: &schema::ObjectType<String>) -> (TypeName, Self) {
+    fn new_object(
+        object_definition: &schema::ObjectType<String>,
+    ) -> (TypeName, Self, Vec<TypeName>) {
+        let interfaces = object_definition
+            .implements_interfaces
+            .iter()
+            .map(|interface_name| interface_name.to_owned().into())
+            .collect();
+
         (
             object_definition.name.to_owned().into(),
             Self::Object {
@@ -255,6 +317,39 @@ impl TypeDef {
                     })
                     .collect(),
                 description: object_definition.description.to_owned(),
+            },
+            interfaces,
+        )
+    }
+    fn new_interface(interface_definition: &schema::InterfaceType<String>) -> (TypeName, Self) {
+        (
+            interface_definition.name.to_owned().into(),
+            Self::Interface {
+                fields: interface_definition
+                    .fields
+                    .iter()
+                    .map(|field| {
+                        (
+                            field.name.to_owned().into(),
+                            ObjectFieldDefinition::new(field),
+                        )
+                    })
+                    .collect(),
+                possible_types: BTreeSet::new(),
+                description: interface_definition.description.to_owned(),
+            },
+        )
+    }
+    fn new_union(union_definition: &schema::UnionType<String>) -> (TypeName, Self) {
+        (
+            union_definition.name.to_owned().into(),
+            Self::Union {
+                members: union_definition
+                    .types
+                    .iter()
+                    .map(|type_name| type_name.to_owned().into())
+                    .collect(),
+                description: union_definition.description.to_owned(),
             },
         )
     }
@@ -371,6 +466,28 @@ pub enum SchemaDefinitionError {
         mutation_field: ProcedureName,
         response_type: TypeName,
     },
+    UnknownTypeReference {
+        referenced_type: TypeName,
+        location: String,
+    },
+    InterfaceWithoutConcreteTypes(TypeName),
+    InterfaceConcreteTypeNotObject {
+        interface_name: TypeName,
+        concrete_type: TypeName,
+    },
+    InterfaceConcreteTypeNotFound {
+        interface_name: TypeName,
+        concrete_type: TypeName,
+    },
+    UnionWithoutConcreteTypes(TypeName),
+    UnionMemberNotObject {
+        union_name: TypeName,
+        member_type: TypeName,
+    },
+    UnionMemberTypeNotFound {
+        union_name: TypeName,
+        member_type: TypeName,
+    },
 }
 
 impl std::error::Error for SchemaDefinitionError {}
@@ -399,6 +516,257 @@ impl Display for SchemaDefinitionError {
                 mutation_field,
                 response_type,
             } => write!(f, "ResponseType name conflict for Mutation field {mutation_field}: A type with name {response_type} already exist. Change the response typename prefix or suffix under  response.typeNamePrefix or response.typeNameSuffix"),
+            SchemaDefinitionError::UnknownTypeReference {
+                referenced_type,
+                location,
+            } => write!(
+                f,
+                "Unknown type reference: {referenced_type} was referenced by {location}, but no matching type exists"
+            ),
+            SchemaDefinitionError::InterfaceWithoutConcreteTypes(interface_name) => write!(
+                f,
+                "Cannot lower interface {interface_name}: no implementing object types were found"
+            ),
+            SchemaDefinitionError::InterfaceConcreteTypeNotObject {
+                interface_name,
+                concrete_type,
+            } => write!(
+                f,
+                "Cannot lower interface {interface_name}: concrete type {concrete_type} is not an object type"
+            ),
+            SchemaDefinitionError::InterfaceConcreteTypeNotFound {
+                interface_name,
+                concrete_type,
+            } => write!(
+                f,
+                "Cannot lower interface {interface_name}: concrete type {concrete_type} was not found"
+            ),
+            SchemaDefinitionError::UnionWithoutConcreteTypes(union_name) => write!(
+                f,
+                "Cannot lower union {union_name}: no concrete object members were found"
+            ),
+            SchemaDefinitionError::UnionMemberNotObject {
+                union_name,
+                member_type,
+            } => write!(
+                f,
+                "Cannot lower union {union_name}: member type {member_type} is not an object type"
+            ),
+            SchemaDefinitionError::UnionMemberTypeNotFound {
+                union_name,
+                member_type,
+            } => write!(
+                f,
+                "Cannot lower union {union_name}: member type {member_type} was not found"
+            ),
         }
+    }
+}
+
+fn validate_definition_type_references(
+    definitions: &BTreeMap<TypeName, TypeDef>,
+    query_fields: &BTreeMap<FunctionName, ObjectFieldDefinition>,
+    mutation_fields: &BTreeMap<ProcedureName, ObjectFieldDefinition>,
+    root_type_names: &BTreeSet<TypeName>,
+) -> Result<(), SchemaDefinitionError> {
+    let validate_type_ref = |type_ref: &TypeRef, location: String| {
+        validate_type_reference(type_ref, definitions, root_type_names, location)
+    };
+
+    for (type_name, type_def) in definitions {
+        match type_def {
+            TypeDef::Interface { possible_types, .. } => {
+                if possible_types.is_empty() {
+                    return Err(SchemaDefinitionError::InterfaceWithoutConcreteTypes(
+                        type_name.clone(),
+                    ));
+                }
+                for possible_type in possible_types {
+                    match definitions.get(possible_type) {
+                        Some(TypeDef::Object { .. }) => {}
+                        Some(_) => {
+                            return Err(SchemaDefinitionError::InterfaceConcreteTypeNotObject {
+                                interface_name: type_name.clone(),
+                                concrete_type: possible_type.clone(),
+                            });
+                        }
+                        None => {
+                            return Err(SchemaDefinitionError::InterfaceConcreteTypeNotFound {
+                                interface_name: type_name.clone(),
+                                concrete_type: possible_type.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+            TypeDef::Union { members, .. } => {
+                if members.is_empty() {
+                    return Err(SchemaDefinitionError::UnionWithoutConcreteTypes(
+                        type_name.clone(),
+                    ));
+                }
+                for member in members {
+                    match definitions.get(member) {
+                        Some(TypeDef::Object { .. }) => {}
+                        Some(_) => {
+                            return Err(SchemaDefinitionError::UnionMemberNotObject {
+                                union_name: type_name.clone(),
+                                member_type: member.clone(),
+                            });
+                        }
+                        None => {
+                            return Err(SchemaDefinitionError::UnionMemberTypeNotFound {
+                                union_name: type_name.clone(),
+                                member_type: member.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+            TypeDef::Scalar { .. }
+            | TypeDef::Enum { .. }
+            | TypeDef::Object { .. }
+            | TypeDef::InputObject { .. } => {}
+        }
+    }
+
+    for (query_field_name, field) in query_fields {
+        validate_type_ref(
+            &field.r#type,
+            format!("query field {query_field_name} return type"),
+        )?;
+        for (argument_name, argument) in &field.arguments {
+            validate_type_ref(
+                &argument.r#type,
+                format!("query field {query_field_name} argument {argument_name}"),
+            )?;
+        }
+    }
+
+    for (mutation_field_name, field) in mutation_fields {
+        validate_type_ref(
+            &field.r#type,
+            format!("mutation field {mutation_field_name} return type"),
+        )?;
+        for (argument_name, argument) in &field.arguments {
+            validate_type_ref(
+                &argument.r#type,
+                format!("mutation field {mutation_field_name} argument {argument_name}"),
+            )?;
+        }
+    }
+
+    for (type_name, type_definition) in definitions {
+        match type_definition {
+            TypeDef::Object { fields, .. } | TypeDef::Interface { fields, .. } => {
+                for (field_name, field) in fields {
+                    validate_type_ref(
+                        &field.r#type,
+                        format!("field {type_name}.{field_name} return type"),
+                    )?;
+                    for (argument_name, argument) in &field.arguments {
+                        validate_type_ref(
+                            &argument.r#type,
+                            format!("field {type_name}.{field_name} argument {argument_name}"),
+                        )?;
+                    }
+                }
+            }
+            TypeDef::InputObject { fields, .. } => {
+                for (field_name, field) in fields {
+                    validate_type_ref(
+                        &field.r#type,
+                        format!("input field {type_name}.{field_name}"),
+                    )?;
+                }
+            }
+            TypeDef::Scalar { .. } | TypeDef::Enum { .. } | TypeDef::Union { .. } => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_type_reference(
+    type_ref: &TypeRef,
+    definitions: &BTreeMap<TypeName, TypeDef>,
+    root_type_names: &BTreeSet<TypeName>,
+    location: String,
+) -> Result<(), SchemaDefinitionError> {
+    match type_ref {
+        TypeRef::Named(name) => {
+            let type_name: TypeName = name.to_owned().into();
+            if !definitions.contains_key(&type_name) && !root_type_names.contains(&type_name) {
+                Err(SchemaDefinitionError::UnknownTypeReference {
+                    referenced_type: type_name,
+                    location,
+                })
+            } else {
+                Ok(())
+            }
+        }
+        TypeRef::List(inner) | TypeRef::NonNull(inner) => {
+            validate_type_reference(inner, definitions, root_type_names, location)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SchemaDefinition, SchemaDefinitionError};
+    use crate::config::{RequestConfig, ResponseConfig};
+
+    #[test]
+    fn interface_without_concrete_types_errors() {
+        let schema_document = graphql_parser::parse_schema::<String>(
+            r#"
+            schema { query: Query }
+            scalar ID
+            type Query {
+              account: PartyAccountRelationship
+            }
+            interface PartyAccountRelationship {
+              relId: ID!
+            }
+            "#,
+        )
+        .expect("test schema should parse");
+
+        let error = SchemaDefinition::new(
+            &schema_document,
+            &RequestConfig::default(),
+            &ResponseConfig::default(),
+        )
+        .expect_err("schema should fail validation");
+
+        assert!(matches!(
+            error,
+            SchemaDefinitionError::InterfaceWithoutConcreteTypes(_)
+        ));
+    }
+
+    #[test]
+    fn unknown_type_reference_errors() {
+        let schema_document = graphql_parser::parse_schema::<String>(
+            r#"
+            schema { query: Query }
+            type Query {
+              account: UnknownType
+            }
+            "#,
+        )
+        .expect("test schema should parse");
+
+        let error = SchemaDefinition::new(
+            &schema_document,
+            &RequestConfig::default(),
+            &ResponseConfig::default(),
+        )
+        .expect_err("schema should fail validation");
+
+        assert!(matches!(
+            error,
+            SchemaDefinitionError::UnknownTypeReference { .. }
+        ));
     }
 }

--- a/crates/common/src/schema_response.rs
+++ b/crates/common/src/schema_response.rs
@@ -18,12 +18,21 @@ pub fn schema_response(
 ) -> SchemaResponse {
     let forward_request_headers = !request.forward_headers.is_empty();
     let forward_response_headers = !response.forward_headers.is_empty();
+    let has_polymorphic_types = schema.definitions.values().any(|definition| {
+        matches!(
+            definition,
+            TypeDef::Interface { .. } | TypeDef::Union { .. }
+        )
+    });
 
     let mut scalar_types: BTreeMap<_, _> = schema
         .definitions
         .iter()
         .filter_map(|(name, typedef)| match typedef {
-            TypeDef::Object { .. } | TypeDef::InputObject { .. } => None,
+            TypeDef::Object { .. }
+            | TypeDef::InputObject { .. }
+            | TypeDef::Interface { .. }
+            | TypeDef::Union { .. } => None,
             TypeDef::Scalar { description: _ } => Some((
                 name.to_owned().into(),
                 models::ScalarType {
@@ -50,6 +59,18 @@ pub fn schema_response(
         })
         .collect();
 
+    if has_polymorphic_types && !scalar_types.contains_key("String") {
+        scalar_types.insert(
+            "String".into(),
+            models::ScalarType {
+                representation: models::TypeRepresentation::String,
+                aggregate_functions: BTreeMap::new(),
+                comparison_operators: BTreeMap::new(),
+                extraction_functions: BTreeMap::new(),
+            },
+        );
+    }
+
     // add headers type name for either header forwarding or request-level arguments
     scalar_types.insert(
         request.headers_type_name.to_owned(),
@@ -61,35 +82,93 @@ pub fn schema_response(
         },
     );
 
-    let mut object_types: BTreeMap<_, _> = schema
-        .definitions
-        .iter()
-        .filter_map(|(name, typedef)| match typedef {
-            TypeDef::Scalar { .. } | TypeDef::Enum { .. } => None,
+    let mut object_types: BTreeMap<_, _> = BTreeMap::new();
+    for (name, typedef) in &schema.definitions {
+        match typedef {
+            TypeDef::Scalar { .. } | TypeDef::Enum { .. } => {}
             TypeDef::Object {
                 fields,
                 description,
-            } => Some((
-                name.to_owned().into(),
-                models::ObjectType {
-                    description: description.to_owned(),
-                    fields: fields.iter().map(map_object_field).collect(),
-                    foreign_keys: BTreeMap::new(),
-                },
-            )),
+            } => {
+                object_types.insert(
+                    name.to_owned().into(),
+                    models::ObjectType {
+                        description: description.to_owned(),
+                        fields: fields.iter().map(map_object_field).collect(),
+                        foreign_keys: BTreeMap::new(),
+                    },
+                );
+            }
+            TypeDef::Interface {
+                fields,
+                possible_types,
+                description,
+            } => {
+                let mut variant_types = Vec::new();
+                for concrete_type in possible_types {
+                    let Some(TypeDef::Object {
+                        fields: concrete_fields,
+                        ..
+                    }) = schema.definitions.get(concrete_type)
+                    else {
+                        continue;
+                    };
+
+                    let exclusive_fields =
+                        interface_exclusive_fields(fields, concrete_fields);
+                    if exclusive_fields.is_empty() {
+                        continue;
+                    }
+
+                    let variant_type_name = polymorphic_variant_type_name(name, concrete_type);
+                    object_types.insert(
+                        variant_type_name.to_owned().into(),
+                        models::ObjectType {
+                            description: Some(format!(
+                                "Fields available only when runtime type is {concrete_type} for polymorphic type {name}"
+                            )),
+                            fields: exclusive_fields.iter().map(map_object_field).collect(),
+                            foreign_keys: BTreeMap::new(),
+                        },
+                    );
+                    variant_types
+                        .push((concrete_type.to_string(), variant_type_name.to_string()));
+                }
+
+                object_types.insert(
+                    name.to_owned().into(),
+                    polymorphic_object_type(name, description, Some(fields), variant_types.into_iter()),
+                );
+            }
+            TypeDef::Union {
+                members,
+                description,
+            } => {
+                object_types.insert(
+                    name.to_owned().into(),
+                    polymorphic_object_type(
+                        name,
+                        description,
+                        None,
+                        members.iter().map(|member| (member.to_string(), member.to_string())),
+                    ),
+                );
+            }
             TypeDef::InputObject {
                 fields,
                 description,
-            } => Some((
-                name.to_owned().into(),
-                models::ObjectType {
-                    description: description.to_owned(),
-                    fields: fields.iter().map(map_input_object_field).collect(),
-                    foreign_keys: BTreeMap::new(),
-                },
-            )),
-        })
-        .collect();
+            } => {
+                object_types.insert(
+                    name.to_owned().into(),
+                    models::ObjectType {
+                        description: description.to_owned(),
+                        fields: fields.iter().map(map_input_object_field).collect(),
+                        foreign_keys: BTreeMap::new(),
+                    },
+                );
+            }
+        }
+    }
 
     let response_type =
         |field: &ObjectFieldDefinition, operation_type: &str, operation_name: &FieldName| {
@@ -238,6 +317,73 @@ pub fn schema_response(
         capabilities: None,
         request_arguments: Some(request_level_arguments),
     }
+}
+
+fn polymorphic_object_type<I>(
+    type_name: &TypeName,
+    description: &Option<String>,
+    common_fields: Option<&BTreeMap<FieldName, ObjectFieldDefinition>>,
+    concrete_types: I,
+) -> models::ObjectType
+where
+    I: Iterator<Item = (String, String)>,
+{
+    let mut fields: BTreeMap<FieldName, models::ObjectField> = common_fields
+        .map(|fields| fields.iter().map(map_object_field).collect())
+        .unwrap_or_default();
+
+    fields.insert(
+        "__typename".into(),
+        models::ObjectField {
+            description: Some(format!(
+                "Concrete GraphQL type name for polymorphic type {type_name}"
+            )),
+            r#type: models::Type::Named {
+                name: "String".to_owned().into(),
+            },
+            arguments: BTreeMap::new(),
+        },
+    );
+
+    for (concrete_type, concrete_type_output) in concrete_types {
+        fields.insert(
+            format!("on_{concrete_type}").into(),
+            models::ObjectField {
+                description: Some(format!(
+                    "Fields available when runtime type is {concrete_type}"
+                )),
+                r#type: models::Type::Nullable {
+                    underlying_type: Box::new(models::Type::Named {
+                        name: concrete_type_output.to_owned().into(),
+                    }),
+                },
+                arguments: BTreeMap::new(),
+            },
+        );
+    }
+
+    models::ObjectType {
+        description: description.to_owned(),
+        fields,
+        foreign_keys: BTreeMap::new(),
+    }
+}
+
+fn interface_exclusive_fields(
+    common_fields: &BTreeMap<FieldName, ObjectFieldDefinition>,
+    concrete_fields: &BTreeMap<FieldName, ObjectFieldDefinition>,
+) -> BTreeMap<FieldName, ObjectFieldDefinition> {
+    concrete_fields
+        .iter()
+        .filter(|(field_name, _)| !common_fields.contains_key(*field_name))
+        .map(|(field_name, field_definition)| {
+            (field_name.to_owned(), field_definition.to_owned())
+        })
+        .collect()
+}
+
+fn polymorphic_variant_type_name(type_name: &TypeName, concrete_type: &TypeName) -> TypeName {
+    format!("{type_name}On{concrete_type}").into()
 }
 
 fn map_object_field(

--- a/crates/common/src/schema_response.rs
+++ b/crates/common/src/schema_response.rs
@@ -114,8 +114,7 @@ pub fn schema_response(
                         continue;
                     };
 
-                    let exclusive_fields =
-                        interface_exclusive_fields(fields, concrete_fields);
+                    let exclusive_fields = interface_exclusive_fields(fields, concrete_fields);
                     if exclusive_fields.is_empty() {
                         continue;
                     }
@@ -131,13 +130,17 @@ pub fn schema_response(
                             foreign_keys: BTreeMap::new(),
                         },
                     );
-                    variant_types
-                        .push((concrete_type.to_string(), variant_type_name.to_string()));
+                    variant_types.push((concrete_type.to_string(), variant_type_name.to_string()));
                 }
 
                 object_types.insert(
                     name.to_owned().into(),
-                    polymorphic_object_type(name, description, Some(fields), variant_types.into_iter()),
+                    polymorphic_object_type(
+                        name,
+                        description,
+                        Some(fields),
+                        variant_types.into_iter(),
+                    ),
                 );
             }
             TypeDef::Union {
@@ -150,7 +153,9 @@ pub fn schema_response(
                         name,
                         description,
                         None,
-                        members.iter().map(|member| (member.to_string(), member.to_string())),
+                        members
+                            .iter()
+                            .map(|member| (member.to_string(), member.to_string())),
                     ),
                 );
             }
@@ -376,9 +381,7 @@ fn interface_exclusive_fields(
     concrete_fields
         .iter()
         .filter(|(field_name, _)| !common_fields.contains_key(*field_name))
-        .map(|(field_name, field_definition)| {
-            (field_name.to_owned(), field_definition.to_owned())
-        })
+        .map(|(field_name, field_definition)| (field_name.to_owned(), field_definition.to_owned()))
         .collect()
 }
 

--- a/crates/ndc-graphql/src/connector/mutation.rs
+++ b/crates/ndc-graphql/src/connector/mutation.rs
@@ -1,13 +1,19 @@
 use super::state::ServerState;
 use crate::query_builder::build_mutation_document;
 use common::{
-    client::{execute_graphql, GraphQLRequest},
+    client::{execute_graphql, GraphQLClientError, GraphQLRequest},
     config::ServerConfig,
 };
 use indexmap::IndexMap;
 use ndc_sdk::{connector::MutationError, models};
 use std::{collections::BTreeMap, mem};
 use tracing::{Instrument, Level};
+
+/// Converts a GraphQLClientError into a MutationError with appropriate details
+fn graphql_client_error_to_mutation_error(err: &GraphQLClientError) -> MutationError {
+    let details = err.to_details();
+    MutationError::new_invalid_request(&err).with_details(details)
+}
 
 pub async fn handle_mutation_explain(
     configuration: &ServerConfig,
@@ -67,10 +73,15 @@ pub async fn handle_mutation(
     )
     .instrument(execution_span)
     .await
-    .map_err(|err| MutationError::new_unprocessable_content(&err))?;
+    .map_err(|err| graphql_client_error_to_mutation_error(&err))?;
 
     tracing::info_span!("Process Response").in_scope(|| {
         if let Some(errors) = response.errors {
+            tracing::warn!(
+                error_count = errors.len(),
+                first_error = %errors[0].message,
+                "GraphQL mutation response contains errors"
+            );
             Err(MutationError::new_unprocessable_content(&errors[0].message)
                 .with_details(serde_json::json!({ "errors": errors })))
         } else if let Some(mut data) = response.data {

--- a/crates/ndc-graphql/src/connector/query.rs
+++ b/crates/ndc-graphql/src/connector/query.rs
@@ -107,14 +107,12 @@ pub async fn handle_query(
 
                     for index in 1..=variables.len() {
                         let alias: FieldName = format!("q{index}__value").into();
-                        let value = data.get(&alias).cloned().unwrap_or(
-                            models::RowFieldValue(serde_json::Value::Null),
-                        );
+                        let value = data
+                            .get(&alias)
+                            .cloned()
+                            .unwrap_or(models::RowFieldValue(serde_json::Value::Null));
 
-                        let row = IndexMap::from_iter(vec![(
-                            FieldName::from("__value"),
-                            value,
-                        )]);
+                        let row = IndexMap::from_iter(vec![(FieldName::from("__value"), value)]);
 
                         let row = if forward_response_headers {
                             wrap_row_with_headers(row, &headers, configuration)?
@@ -160,10 +158,10 @@ fn wrap_row_with_headers(
     headers: &BTreeMap<String, String>,
     configuration: &ServerConfig,
 ) -> Result<IndexMap<FieldName, models::RowFieldValue>, QueryError> {
-    let headers = serde_json::to_value(headers)
-        .map_err(|err| QueryError::new_unprocessable_content(&err))?;
-    let data = serde_json::to_value(data)
-        .map_err(|err| QueryError::new_unprocessable_content(&err))?;
+    let headers =
+        serde_json::to_value(headers).map_err(|err| QueryError::new_unprocessable_content(&err))?;
+    let data =
+        serde_json::to_value(data).map_err(|err| QueryError::new_unprocessable_content(&err))?;
 
     Ok(IndexMap::from_iter(vec![
         (

--- a/crates/ndc-graphql/src/connector/query.rs
+++ b/crates/ndc-graphql/src/connector/query.rs
@@ -80,40 +80,90 @@ pub async fn handle_query(
             Err(QueryError::new_unprocessable_content(&errors[0].message)
                 .with_details(serde_json::json!({ "errors": errors })))
         } else if let Some(data) = response.data {
+            #[cfg(debug_assertions)]
+            {
+                let response_string = serde_json::to_string(&data)
+                    .map_err(|err| QueryError::new_unprocessable_content(&err))?;
+                tracing::event!(Level::DEBUG, "Upstream Response" = response_string);
+            }
+
             let data = normalize_query_data(data, &request, configuration)?;
             let forward_response_headers = !configuration.response.forward_headers.is_empty();
 
-            let row = if forward_response_headers {
-                let headers = serde_json::to_value(headers)
-                    .map_err(|err| QueryError::new_unprocessable_content(&err))?;
-                let data = serde_json::to_value(data)
-                    .map_err(|err| QueryError::new_unprocessable_content(&err))?;
+            let row_sets = match &request.variables {
+                Some(variables) if !variables.is_empty() => {
+                    let mut row_sets = Vec::with_capacity(variables.len());
 
-                IndexMap::from_iter(vec![
-                    (
-                        configuration.response.headers_field.to_string().into(),
-                        models::RowFieldValue(headers),
-                    ),
-                    (
-                        configuration.response.response_field.to_string().into(),
-                        models::RowFieldValue(data),
-                    ),
-                ])
-            } else {
-                data
+                    for index in 1..=variables.len() {
+                        let alias: FieldName = format!("q{index}__value").into();
+                        let value = data.get(&alias).cloned().unwrap_or(
+                            models::RowFieldValue(serde_json::Value::Null),
+                        );
+
+                        let row = IndexMap::from_iter(vec![(
+                            FieldName::from("__value"),
+                            value,
+                        )]);
+
+                        let row = if forward_response_headers {
+                            wrap_row_with_headers(row, &headers, configuration)?
+                        } else {
+                            row
+                        };
+
+                        row_sets.push(models::RowSet {
+                            groups: None,
+                            aggregates: None,
+                            rows: Some(vec![row]),
+                        });
+                    }
+
+                    row_sets
+                }
+                _ => {
+                    let row = if forward_response_headers {
+                        wrap_row_with_headers(data, &headers, configuration)?
+                    } else {
+                        data
+                    };
+
+                    vec![models::RowSet {
+                        groups: None,
+                        aggregates: None,
+                        rows: Some(vec![row]),
+                    }]
+                }
             };
 
-            Ok(models::QueryResponse(vec![models::RowSet {
-                groups: None,
-                aggregates: None,
-                rows: Some(vec![row]),
-            }]))
+            Ok(models::QueryResponse(row_sets))
         } else {
             Err(QueryError::new_unprocessable_content(
                 &"No data or errors in response",
             ))
         }
     })
+}
+
+fn wrap_row_with_headers(
+    data: IndexMap<FieldName, models::RowFieldValue>,
+    headers: &BTreeMap<String, String>,
+    configuration: &ServerConfig,
+) -> Result<IndexMap<FieldName, models::RowFieldValue>, QueryError> {
+    let headers = serde_json::to_value(headers)
+        .map_err(|err| QueryError::new_unprocessable_content(&err))?;
+    let data = serde_json::to_value(data)
+        .map_err(|err| QueryError::new_unprocessable_content(&err))?;
+
+    Ok(IndexMap::from_iter(vec![
+        (
+            configuration.response.headers_field.to_string().into(),
+            models::RowFieldValue(headers),
+        ),
+        (
+            configuration.response.response_field.to_string().into(),
+            models::RowFieldValue(data),
+        ),
+    ]))
 }
 
 fn normalize_query_data(
@@ -666,6 +716,103 @@ mod tests {
             .swap_remove(&old_alias)
             .expect("request should contain polymorphic field alias");
         relationship_object.fields.insert(new_alias, field);
+    }
+
+    #[tokio::test]
+    async fn normalizes_foreach_response_into_separate_row_sets() {
+        let configuration = read_configuration("config-1").await;
+        let request_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("config-1")
+            .join("queries")
+            .join("04_foreach.request.json");
+        let request: models::QueryRequest =
+            serde_json::from_str(&fs::read_to_string(request_path).unwrap()).unwrap();
+
+        // Simulate upstream response with aliased keys
+        let data = IndexMap::from([
+            (
+                FieldName::from("q1__value"),
+                models::RowFieldValue(json!({
+                    "AlbumId": 1,
+                    "Title": "Album One",
+                    "Artist": { "ArtistId": 1, "Name": "Artist One" },
+                    "Tracks": []
+                })),
+            ),
+            (
+                FieldName::from("q2__value"),
+                models::RowFieldValue(json!({
+                    "AlbumId": 2,
+                    "Title": "Album Two",
+                    "Artist": { "ArtistId": 2, "Name": "Artist Two" },
+                    "Tracks": []
+                })),
+            ),
+            (
+                FieldName::from("q3__value"),
+                models::RowFieldValue(json!({
+                    "AlbumId": 3,
+                    "Title": "Album Three",
+                    "Artist": { "ArtistId": 3, "Name": "Artist Three" },
+                    "Tracks": []
+                })),
+            ),
+        ]);
+
+        let normalized = normalize_query_data(data, &request, &configuration)
+            .expect("Should normalize foreach response");
+
+        // Verify the normalized data still has qN__value keys
+        assert!(normalized.contains_key(&FieldName::from("q1__value")));
+        assert!(normalized.contains_key(&FieldName::from("q2__value")));
+        assert!(normalized.contains_key(&FieldName::from("q3__value")));
+
+        // Now simulate what handle_query does: split into separate RowSets
+        let variables = request.variables.as_ref().unwrap();
+        let mut row_sets = Vec::with_capacity(variables.len());
+        for index in 1..=variables.len() {
+            let alias: FieldName = format!("q{index}__value").into();
+            let value = normalized
+                .get(&alias)
+                .cloned()
+                .unwrap_or(models::RowFieldValue(serde_json::Value::Null));
+            let row = IndexMap::from_iter(vec![(FieldName::from("__value"), value)]);
+            row_sets.push(models::RowSet {
+                groups: None,
+                aggregates: None,
+                rows: Some(vec![row]),
+            });
+        }
+
+        // Should produce 3 RowSets, one per variable set
+        assert_eq!(row_sets.len(), 3);
+
+        // Each RowSet should have exactly one row with __value key
+        for (i, row_set) in row_sets.iter().enumerate() {
+            let rows = row_set.rows.as_ref().unwrap();
+            assert_eq!(rows.len(), 1, "RowSet {i} should have exactly one row");
+            assert!(
+                rows[0].contains_key(&FieldName::from("__value")),
+                "RowSet {i} row should have __value key"
+            );
+            assert!(
+                !rows[0].contains_key(&FieldName::from(format!("q{}__value", i + 1))),
+                "RowSet {i} row should NOT have aliased key"
+            );
+        }
+
+        // Verify the data content is correct
+        let row0 = &row_sets[0].rows.as_ref().unwrap()[0];
+        assert_eq!(
+            row0.get(&FieldName::from("__value")).unwrap().0["AlbumId"],
+            json!(1)
+        );
+        let row2 = &row_sets[2].rows.as_ref().unwrap()[0];
+        assert_eq!(
+            row2.get(&FieldName::from("__value")).unwrap().0["AlbumId"],
+            json!(3)
+        );
     }
 
     fn replace_relationship_selection_with_common_field(

--- a/crates/ndc-graphql/src/connector/query.rs
+++ b/crates/ndc-graphql/src/connector/query.rs
@@ -2,14 +2,17 @@ use super::state::ServerState;
 use crate::query_builder::build_query_document;
 use common::{
     client::{execute_graphql, GraphQLRequest},
-    config::ServerConfig,
+    config::{
+        schema::{ObjectFieldDefinition, TypeDef},
+        ServerConfig,
+    },
 };
 use indexmap::IndexMap;
 use ndc_sdk::{
     connector::QueryError,
     models::{self, FieldName},
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use tracing::{Instrument, Level};
 
 pub async fn handle_query_explain(
@@ -77,6 +80,7 @@ pub async fn handle_query(
             Err(QueryError::new_unprocessable_content(&errors[0].message)
                 .with_details(serde_json::json!({ "errors": errors })))
         } else if let Some(data) = response.data {
+            let data = normalize_query_data(data, &request, configuration)?;
             let forward_response_headers = !configuration.response.forward_headers.is_empty();
 
             let row = if forward_response_headers {
@@ -110,4 +114,599 @@ pub async fn handle_query(
             ))
         }
     })
+}
+
+fn normalize_query_data(
+    data: IndexMap<FieldName, models::RowFieldValue>,
+    request: &models::QueryRequest,
+    configuration: &ServerConfig,
+) -> Result<IndexMap<FieldName, models::RowFieldValue>, QueryError> {
+    let root_field = request
+        .query
+        .fields
+        .as_ref()
+        .and_then(|fields| fields.get("__value"))
+        .ok_or_else(|| {
+            QueryError::new_invalid_request(&"Misshapen request: no fields for query")
+        })?;
+
+    let (root_nested_fields, root_field_definition) = match root_field {
+        models::Field::Column { column, fields, .. } if column.inner() == "__value" => {
+            let root_field_definition = configuration
+                .schema
+                .query_fields
+                .get(&request.collection)
+                .ok_or_else(|| {
+                    QueryError::new_invalid_request(&format!(
+                        "Field {} not found in Query type",
+                        request.collection
+                    ))
+                })?;
+            (fields.as_ref(), root_field_definition)
+        }
+        models::Field::Column { column, .. } => {
+            return Err(QueryError::new_invalid_request(&format!(
+                "Expected field with key __value, got {column}"
+            )));
+        }
+        models::Field::Relationship { .. } => {
+            return Err(QueryError::new_invalid_request(
+                &"Misshapen request: root __value field cannot be a relationship",
+            ));
+        }
+    };
+
+    let mut normalized = IndexMap::with_capacity(data.len());
+    for (field_name, row_field_value) in data {
+        if is_root_value_alias(field_name.inner()) {
+            let normalized_value = normalize_field_value(
+                row_field_value.0,
+                root_nested_fields,
+                root_field_definition,
+                &configuration.schema.definitions,
+            )?;
+            normalized.insert(field_name, models::RowFieldValue(normalized_value));
+        } else {
+            normalized.insert(field_name, row_field_value);
+        }
+    }
+
+    Ok(normalized)
+}
+
+fn is_root_value_alias(alias: &str) -> bool {
+    if alias == "__value" {
+        return true;
+    }
+
+    alias
+        .strip_prefix('q')
+        .and_then(|tail| tail.strip_suffix("__value"))
+        .is_some_and(|index| !index.is_empty() && index.chars().all(|ch| ch.is_ascii_digit()))
+}
+
+fn normalize_field_value(
+    value: serde_json::Value,
+    nested_field: Option<&models::NestedField>,
+    field_definition: &ObjectFieldDefinition,
+    definitions: &BTreeMap<models::TypeName, TypeDef>,
+) -> Result<serde_json::Value, QueryError> {
+    let Some(nested_field) = nested_field else {
+        return Ok(value);
+    };
+
+    if value.is_null() {
+        return Ok(value);
+    }
+
+    match nested_field {
+        models::NestedField::Array(array) => match value {
+            serde_json::Value::Array(values) => {
+                let mut normalized_values = Vec::with_capacity(values.len());
+                for value in values {
+                    normalized_values.push(normalize_field_value(
+                        value,
+                        Some(&array.fields),
+                        field_definition,
+                        definitions,
+                    )?);
+                }
+                Ok(serde_json::Value::Array(normalized_values))
+            }
+            other => Ok(other),
+        },
+        models::NestedField::Object(object) => {
+            normalize_object_like_value(value, &object.fields, field_definition, definitions)
+        }
+        models::NestedField::Collection(_) => Ok(value),
+    }
+}
+
+fn normalize_object_like_value(
+    value: serde_json::Value,
+    requested_fields: &IndexMap<FieldName, models::Field>,
+    field_definition: &ObjectFieldDefinition,
+    definitions: &BTreeMap<models::TypeName, TypeDef>,
+) -> Result<serde_json::Value, QueryError> {
+    let object_name = field_definition.r#type.name();
+    match definitions.get(&object_name) {
+        Some(TypeDef::Object { fields, .. }) => {
+            normalize_object_value(value, requested_fields, fields, definitions)
+        }
+        Some(TypeDef::Interface { possible_types, .. }) => {
+            let common_fields = match definitions.get(&object_name) {
+                Some(TypeDef::Interface { fields, .. }) => Some(fields),
+                _ => None,
+            };
+            normalize_polymorphic_value(
+                value,
+                requested_fields,
+                possible_types,
+                common_fields,
+                definitions,
+            )
+        }
+        Some(TypeDef::Union { members, .. }) => {
+            normalize_polymorphic_value(value, requested_fields, members, None, definitions)
+        }
+        Some(_) | None => Ok(value),
+    }
+}
+
+fn normalize_object_value(
+    value: serde_json::Value,
+    requested_fields: &IndexMap<FieldName, models::Field>,
+    object_fields: &BTreeMap<FieldName, ObjectFieldDefinition>,
+    definitions: &BTreeMap<models::TypeName, TypeDef>,
+) -> Result<serde_json::Value, QueryError> {
+    let source = match value {
+        serde_json::Value::Object(source) => source,
+        other => return Ok(other),
+    };
+
+    let normalized =
+        normalize_object_from_source(&source, requested_fields, object_fields, definitions)?;
+    Ok(serde_json::Value::Object(normalized))
+}
+
+fn normalize_object_from_source(
+    source: &serde_json::Map<String, serde_json::Value>,
+    requested_fields: &IndexMap<FieldName, models::Field>,
+    object_fields: &BTreeMap<FieldName, ObjectFieldDefinition>,
+    definitions: &BTreeMap<models::TypeName, TypeDef>,
+) -> Result<serde_json::Map<String, serde_json::Value>, QueryError> {
+    let mut normalized = serde_json::Map::new();
+
+    for (alias, field) in requested_fields {
+        let (column, nested_field) = match field {
+            models::Field::Column { column, fields, .. } => (column, fields.as_ref()),
+            models::Field::Relationship { .. } => continue,
+        };
+
+        let field_definition = object_fields.get(column).ok_or_else(|| {
+            QueryError::new_invalid_request(&format!(
+                "Field {column} is not defined in object type for response shaping"
+            ))
+        })?;
+
+        if let Some(value) = lookup_requested_value(source, alias, column) {
+            let normalized_value =
+                normalize_field_value(value, nested_field, field_definition, definitions)?;
+            normalized.insert(alias.to_string(), normalized_value);
+        }
+    }
+
+    Ok(normalized)
+}
+
+fn normalize_polymorphic_value(
+    value: serde_json::Value,
+    requested_fields: &IndexMap<FieldName, models::Field>,
+    concrete_types: &BTreeSet<models::TypeName>,
+    common_fields: Option<&BTreeMap<FieldName, ObjectFieldDefinition>>,
+    definitions: &BTreeMap<models::TypeName, TypeDef>,
+) -> Result<serde_json::Value, QueryError> {
+    let source = match value {
+        serde_json::Value::Object(source) => source,
+        other => return Ok(other),
+    };
+
+    let runtime_type_name = runtime_type_name(&source, requested_fields);
+    let mut normalized = serde_json::Map::new();
+
+    for (alias, field) in requested_fields {
+        let (column, nested_field) = match field {
+            models::Field::Column { column, fields, .. } => (column, fields.as_ref()),
+            models::Field::Relationship { .. } => continue,
+        };
+
+        if column.inner() == "__typename" {
+            if let Some(value) = lookup_requested_value(&source, alias, column) {
+                normalized.insert(alias.to_string(), value);
+            }
+            continue;
+        }
+
+        let Some(concrete_type_name) = column.inner().strip_prefix("on_") else {
+            if let (Some(field_definition), Some(value)) = (
+                common_fields.and_then(|fields| fields.get(column)),
+                lookup_requested_value(&source, alias, column),
+            ) {
+                let normalized_value =
+                    normalize_field_value(value, nested_field, field_definition, definitions)?;
+                normalized.insert(alias.to_string(), normalized_value);
+            }
+            continue;
+        };
+
+        let concrete_type: models::TypeName = concrete_type_name.to_owned().into();
+        if !concrete_types.contains(&concrete_type) {
+            if let Some(value) = lookup_requested_value(&source, alias, column) {
+                normalized.insert(alias.to_string(), value);
+            }
+            continue;
+        }
+
+        if runtime_type_name != Some(concrete_type_name) {
+            normalized.insert(alias.to_string(), serde_json::Value::Null);
+            continue;
+        }
+
+        let requested_subfields = nested_field.and_then(underlying_fields).ok_or_else(|| {
+            QueryError::new_invalid_request(&format!(
+                "Field {column} requires nested object fields for polymorphic response shaping"
+            ))
+        })?;
+
+        let concrete_object_fields = match definitions.get(&concrete_type) {
+            Some(TypeDef::Object { fields, .. }) => fields,
+            Some(_) => {
+                return Err(QueryError::new_invalid_request(&format!(
+                    "Type {concrete_type} is not an object type for polymorphic response shaping"
+                )));
+            }
+            None => {
+                return Err(QueryError::new_invalid_request(&format!(
+                    "Type {concrete_type} not found for polymorphic response shaping"
+                )));
+            }
+        };
+        let concrete_variant_fields =
+            interface_exclusive_fields(concrete_object_fields, common_fields);
+
+        let variant_object = normalize_object_from_source(
+            &source,
+            requested_subfields,
+            &concrete_variant_fields,
+            definitions,
+        )?;
+        normalized.insert(alias.to_string(), serde_json::Value::Object(variant_object));
+    }
+
+    Ok(serde_json::Value::Object(normalized))
+}
+
+fn underlying_fields(
+    nested_field: &models::NestedField,
+) -> Option<&IndexMap<FieldName, models::Field>> {
+    match nested_field {
+        models::NestedField::Object(object) => Some(&object.fields),
+        models::NestedField::Array(array) => underlying_fields(&array.fields),
+        models::NestedField::Collection(_) => None,
+    }
+}
+
+fn lookup_requested_value(
+    source: &serde_json::Map<String, serde_json::Value>,
+    alias: &FieldName,
+    column: &FieldName,
+) -> Option<serde_json::Value> {
+    source
+        .get(alias.inner().as_str())
+        .cloned()
+        .or_else(|| source.get(column.inner().as_str()).cloned())
+}
+
+fn runtime_type_name<'a>(
+    source: &'a serde_json::Map<String, serde_json::Value>,
+    requested_fields: &IndexMap<FieldName, models::Field>,
+) -> Option<&'a str> {
+    for (alias, field) in requested_fields {
+        let models::Field::Column { column, .. } = field else {
+            continue;
+        };
+        if column.inner() == "__typename" {
+            if let Some(name) = source
+                .get(alias.inner().as_str())
+                .or_else(|| source.get(column.inner().as_str()))
+                .and_then(serde_json::Value::as_str)
+            {
+                return Some(name);
+            }
+        }
+    }
+
+    source.get("__typename").and_then(serde_json::Value::as_str)
+}
+
+fn interface_exclusive_fields(
+    concrete_fields: &BTreeMap<FieldName, ObjectFieldDefinition>,
+    common_fields: Option<&BTreeMap<FieldName, ObjectFieldDefinition>>,
+) -> BTreeMap<FieldName, ObjectFieldDefinition> {
+    match common_fields {
+        Some(common_fields) => concrete_fields
+            .iter()
+            .filter(|(field_name, _)| !common_fields.contains_key(*field_name))
+            .map(|(field_name, field_definition)| {
+                (field_name.to_owned(), field_definition.to_owned())
+            })
+            .collect(),
+        None => concrete_fields
+            .iter()
+            .map(|(field_name, field_definition)| {
+                (field_name.to_owned(), field_definition.to_owned())
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_query_data;
+    use crate::connector::setup::GraphQLConnectorSetup;
+    use common::config::ServerConfig;
+    use indexmap::IndexMap;
+    use ndc_sdk::models::{self, FieldName};
+    use serde_json::json;
+    use std::{
+        collections::{BTreeMap, HashMap},
+        fs,
+        path::PathBuf,
+    };
+
+    async fn read_configuration(config: &str) -> ServerConfig {
+        let configuration_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join(config)
+            .join("configuration");
+        let env = HashMap::from_iter(vec![
+            ("GRAPHQL_ENDPOINT".to_owned(), String::new()),
+            ("GRAPHQL_ENDPOINT_SECRET".to_owned(), String::new()),
+        ]);
+        GraphQLConnectorSetup::new(env)
+            .read_configuration(configuration_dir)
+            .await
+            .expect("Should read test configuration")
+    }
+
+    fn read_polymorphic_request() -> models::QueryRequest {
+        let request_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("config-4")
+            .join("queries")
+            .join("01_polymorphic_query.request.json");
+        let request = fs::read_to_string(request_path).expect("Should read polymorphic request");
+        serde_json::from_str(&request).expect("Should parse request")
+    }
+
+    #[tokio::test]
+    async fn normalizes_polymorphic_response_shape() {
+        let configuration = read_configuration("config-4").await;
+        let request = read_polymorphic_request();
+
+        let data = IndexMap::from([(
+            FieldName::from("__value"),
+            models::RowFieldValue(json!({
+                "id": "acct-1",
+                "relationship": {
+                    "__typename": "PersonRelationship",
+                    "relId": "rel-1",
+                    "personName": "Leia"
+                },
+                "altRelationship": {
+                    "__typename": "OrganizationRelationship",
+                    "relId": "alt-rel"
+                }
+            })),
+        )]);
+
+        let normalized = normalize_query_data(data, &request, &configuration)
+            .expect("Should normalize polymorphic response");
+        let normalized_json = serde_json::to_value(normalized).expect("Should serialize response");
+
+        assert_eq!(
+            normalized_json,
+            json!({
+                "__value": {
+                    "id": "acct-1",
+                    "relationship": {
+                        "__typename": "PersonRelationship",
+                        "relId": "rel-1",
+                        "on_PersonRelationship": {
+                            "personName": "Leia"
+                        },
+                        "on_OrganizationRelationship": null
+                    },
+                    "altRelationship": {
+                        "__typename": "OrganizationRelationship",
+                        "on_PersonRelationship": null
+                    }
+                }
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn normalizes_polymorphic_response_shape_with_alias() {
+        let configuration = read_configuration("config-4").await;
+        let mut request = read_polymorphic_request();
+        rename_polymorphic_alias(
+            &mut request,
+            "relationship",
+            "on_PersonRelationship",
+            "onPerson",
+        );
+        rename_polymorphic_alias(&mut request, "relationship", "__typename", "typename");
+
+        let data = IndexMap::from([(
+            FieldName::from("__value"),
+            models::RowFieldValue(json!({
+                "id": "acct-1",
+                "relationship": {
+                    "typename": "PersonRelationship",
+                    "relId": "rel-1",
+                    "personName": "Leia"
+                },
+                "altRelationship": {
+                    "__typename": "PersonRelationship",
+                    "relId": "alt-rel"
+                }
+            })),
+        )]);
+
+        let normalized = normalize_query_data(data, &request, &configuration)
+            .expect("Should normalize aliased polymorphic response");
+        let normalized_json = serde_json::to_value(normalized).expect("Should serialize response");
+
+        assert_eq!(
+            normalized_json,
+            json!({
+                "__value": {
+                    "id": "acct-1",
+                    "relationship": {
+                        "typename": "PersonRelationship",
+                        "relId": "rel-1",
+                        "onPerson": {
+                            "personName": "Leia"
+                        },
+                        "on_OrganizationRelationship": null
+                    },
+                    "altRelationship": {
+                        "__typename": "PersonRelationship",
+                        "on_PersonRelationship": {
+                            "relId": "alt-rel"
+                        }
+                    }
+                }
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn normalizes_interface_common_field() {
+        let configuration = read_configuration("config-4").await;
+        let mut request = read_polymorphic_request();
+        replace_relationship_selection_with_common_field(&mut request, "relId");
+
+        let data = IndexMap::from([(
+            FieldName::from("__value"),
+            models::RowFieldValue(json!({
+                "id": "acct-1",
+                "relationship": {
+                    "relId": "rel-1"
+                }
+            })),
+        )]);
+
+        let normalized = normalize_query_data(data, &request, &configuration)
+            .expect("Should normalize interface common field");
+        let normalized_json = serde_json::to_value(normalized).expect("Should serialize response");
+
+        assert_eq!(
+            normalized_json,
+            json!({
+                "__value": {
+                    "id": "acct-1",
+                    "relationship": {
+                        "relId": "rel-1"
+                    }
+                }
+            })
+        );
+    }
+
+    fn rename_polymorphic_alias(
+        request: &mut models::QueryRequest,
+        relation_field: &str,
+        old_alias: &str,
+        new_alias: &str,
+    ) {
+        let root_field = request
+            .query
+            .fields
+            .as_mut()
+            .and_then(|fields| fields.get_mut("__value"))
+            .expect("request should contain __value");
+
+        let models::Field::Column {
+            fields: Some(models::NestedField::Object(root_object)),
+            ..
+        } = root_field
+        else {
+            panic!("__value should contain an object selection");
+        };
+
+        let relationship_field = root_object
+            .fields
+            .get_mut(relation_field)
+            .expect("request should contain relationship field");
+
+        let models::Field::Column {
+            fields: Some(models::NestedField::Object(relationship_object)),
+            ..
+        } = relationship_field
+        else {
+            panic!("relationship field should contain an object selection");
+        };
+
+        let old_alias: FieldName = old_alias.into();
+        let new_alias: FieldName = new_alias.into();
+        let field = relationship_object
+            .fields
+            .swap_remove(&old_alias)
+            .expect("request should contain polymorphic field alias");
+        relationship_object.fields.insert(new_alias, field);
+    }
+
+    fn replace_relationship_selection_with_common_field(
+        request: &mut models::QueryRequest,
+        field_name: &str,
+    ) {
+        let root_field = request
+            .query
+            .fields
+            .as_mut()
+            .and_then(|fields| fields.get_mut("__value"))
+            .expect("request should contain __value");
+
+        let models::Field::Column {
+            fields: Some(models::NestedField::Object(root_object)),
+            ..
+        } = root_field
+        else {
+            panic!("__value should contain an object selection");
+        };
+
+        let relationship_field = root_object
+            .fields
+            .get_mut("relationship")
+            .expect("request should contain relationship field");
+
+        let models::Field::Column {
+            fields: Some(models::NestedField::Object(relationship_object)),
+            ..
+        } = relationship_field
+        else {
+            panic!("relationship field should contain an object selection");
+        };
+
+        relationship_object.fields = IndexMap::from([(
+            FieldName::from(field_name),
+            models::Field::Column {
+                column: field_name.into(),
+                fields: None,
+                arguments: BTreeMap::new(),
+            },
+        )]);
+    }
 }

--- a/crates/ndc-graphql/src/connector/query.rs
+++ b/crates/ndc-graphql/src/connector/query.rs
@@ -1,7 +1,7 @@
 use super::state::ServerState;
 use crate::query_builder::build_query_document;
 use common::{
-    client::{execute_graphql, GraphQLRequest},
+    client::{execute_graphql, GraphQLClientError, GraphQLRequest},
     config::{
         schema::{ObjectFieldDefinition, TypeDef},
         ServerConfig,
@@ -14,6 +14,12 @@ use ndc_sdk::{
 };
 use std::collections::{BTreeMap, BTreeSet};
 use tracing::{Instrument, Level};
+
+/// Converts a GraphQLClientError into a QueryError with appropriate details
+fn graphql_client_error_to_query_error(err: &GraphQLClientError) -> QueryError {
+    let details = err.to_details();
+    QueryError::new_invalid_request(&err).with_details(details)
+}
 
 pub async fn handle_query_explain(
     configuration: &ServerConfig,
@@ -73,10 +79,15 @@ pub async fn handle_query(
     )
     .instrument(execution_span)
     .await
-    .map_err(|err| QueryError::new_invalid_request(&err))?;
+    .map_err(|err| graphql_client_error_to_query_error(&err))?;
 
     tracing::info_span!("Process Response").in_scope(|| {
         if let Some(errors) = response.errors {
+            tracing::warn!(
+                error_count = errors.len(),
+                first_error = %errors[0].message,
+                "GraphQL response contains errors"
+            );
             Err(QueryError::new_unprocessable_content(&errors[0].message)
                 .with_details(serde_json::json!({ "errors": errors })))
         } else if let Some(data) = response.data {

--- a/crates/ndc-graphql/src/query_builder.rs
+++ b/crates/ndc-graphql/src/query_builder.rs
@@ -6,8 +6,8 @@ use common::config::{
 use glob_match::glob_match;
 use graphql_parser::{
     query::{
-        Definition, Document, Field, Mutation, OperationDefinition, Query, Selection, SelectionSet,
-        Value,
+        Definition, Document, Field, InlineFragment, Mutation, OperationDefinition, Query,
+        Selection, SelectionSet, TypeCondition, Value,
     },
     Pos,
 };
@@ -363,74 +363,13 @@ fn selection_set_field<'a>(
     configuration: &ServerConfig,
     variables: &BTreeMap<VariableName, serde_json::Value>,
 ) -> Result<Selection<'a, String>, QueryBuilderError> {
-    let selection_set = match fields.as_ref().and_then(underlying_fields) {
-        Some(fields) => {
-            let items = fields
-                .iter()
-                .map(|(alias, field)| {
-                    let (field_name, fields, arguments) = match field {
-                        models::Field::Column {
-                            column,
-                            fields,
-                            arguments,
-                        } => (column, fields, arguments),
-                        models::Field::Relationship { .. } => {
-                            return Err(QueryBuilderError::NotSupported(
-                                "Relationships".to_string(),
-                            ))
-                        }
-                    };
-
-                    let object_name = field_definition.r#type.name();
-
-                    // subfield selection should only exist on object types
-                    let field_definition = match configuration.schema.definitions.get(&object_name)
-                    {
-                        Some(TypeDef::Object {
-                            fields,
-                            description: _,
-                        }) => fields.get(field_name).ok_or_else(|| {
-                            QueryBuilderError::ObjectFieldNotFound {
-                                object: field_definition.r#type.name(),
-                                field: field_name.clone(),
-                            }
-                        }),
-                        Some(_) | None => Err(QueryBuilderError::ObjectTypeNotFound(
-                            field_definition.r#type.name(),
-                        )),
-                    }?;
-
-                    selection_set_field(
-                        &alias.to_string(),
-                        field_name,
-                        field_arguments(
-                            arguments,
-                            map_query_arg,
-                            field_definition,
-                            parameters,
-                            field_name,
-                            &object_name,
-                            variables,
-                        )?,
-                        fields,
-                        field_definition,
-                        parameters,
-                        configuration,
-                        variables,
-                    )
-                })
-                .collect::<Result<_, _>>()?;
-
-            SelectionSet {
-                span: (pos(), pos()),
-                items,
-            }
-        }
-        None => SelectionSet {
-            span: (pos(), pos()),
-            items: vec![],
-        },
-    };
+    let selection_set = selection_set(
+        fields,
+        field_definition,
+        parameters,
+        configuration,
+        variables,
+    )?;
     Ok(Selection::Field(Field {
         position: pos(),
         alias: if alias == field_name.inner() {
@@ -443,6 +382,249 @@ fn selection_set_field<'a>(
         directives: vec![],
         selection_set,
     }))
+}
+
+fn selection_set<'a>(
+    fields: &Option<NestedField>,
+    field_definition: &ObjectFieldDefinition,
+    parameters: &mut OperationParameters,
+    configuration: &ServerConfig,
+    variables: &BTreeMap<VariableName, serde_json::Value>,
+) -> Result<SelectionSet<'a, String>, QueryBuilderError> {
+    let items = match fields.as_ref().and_then(underlying_fields) {
+        Some(requested_fields) => {
+            let object_name = field_definition.r#type.name();
+            match configuration.schema.definitions.get(&object_name) {
+                Some(TypeDef::Object { fields, .. }) => object_selection_items(
+                    &object_name,
+                    fields,
+                    requested_fields,
+                    parameters,
+                    configuration,
+                    variables,
+                ),
+                Some(TypeDef::Interface { possible_types, .. }) => polymorphic_selection_items(
+                    &object_name,
+                    possible_types,
+                    configuration
+                        .schema
+                        .definitions
+                        .get(&object_name)
+                        .and_then(|definition| match definition {
+                            TypeDef::Interface { fields, .. } => Some(fields),
+                            _ => None,
+                        }),
+                    requested_fields,
+                    parameters,
+                    configuration,
+                    variables,
+                ),
+                Some(TypeDef::Union { members, .. }) => polymorphic_selection_items(
+                    &object_name,
+                    members,
+                    None,
+                    requested_fields,
+                    parameters,
+                    configuration,
+                    variables,
+                ),
+                Some(_) | None => Err(QueryBuilderError::ObjectTypeNotFound(object_name)),
+            }?
+        }
+        None => vec![],
+    };
+
+    Ok(SelectionSet {
+        span: (pos(), pos()),
+        items,
+    })
+}
+
+fn object_selection_items<'a>(
+    object_name: &TypeName,
+    object_fields: &BTreeMap<FieldName, ObjectFieldDefinition>,
+    requested_fields: &IndexMap<FieldName, models::Field>,
+    parameters: &mut OperationParameters,
+    configuration: &ServerConfig,
+    variables: &BTreeMap<VariableName, serde_json::Value>,
+) -> Result<Vec<Selection<'a, String>>, QueryBuilderError> {
+    requested_fields
+        .iter()
+        .map(|(alias, field)| {
+            let (field_name, fields, arguments) = match field {
+                models::Field::Column {
+                    column,
+                    fields,
+                    arguments,
+                } => (column, fields, arguments),
+                models::Field::Relationship { .. } => {
+                    return Err(QueryBuilderError::NotSupported("Relationships".to_string()))
+                }
+            };
+
+            let field_definition = object_fields.get(field_name).ok_or_else(|| {
+                QueryBuilderError::ObjectFieldNotFound {
+                    object: object_name.clone(),
+                    field: field_name.clone(),
+                }
+            })?;
+
+            selection_set_field(
+                &alias.to_string(),
+                field_name,
+                field_arguments(
+                    arguments,
+                    map_query_arg,
+                    field_definition,
+                    parameters,
+                    field_name,
+                    object_name,
+                    variables,
+                )?,
+                fields,
+                field_definition,
+                parameters,
+                configuration,
+                variables,
+            )
+        })
+        .collect()
+}
+
+fn polymorphic_selection_items<'a>(
+    object_name: &TypeName,
+    concrete_types: &std::collections::BTreeSet<TypeName>,
+    common_fields: Option<&BTreeMap<FieldName, ObjectFieldDefinition>>,
+    requested_fields: &IndexMap<FieldName, models::Field>,
+    parameters: &mut OperationParameters,
+    configuration: &ServerConfig,
+    variables: &BTreeMap<VariableName, serde_json::Value>,
+) -> Result<Vec<Selection<'a, String>>, QueryBuilderError> {
+    requested_fields
+        .iter()
+        .map(|(alias, field)| {
+            let (field_name, nested_fields, arguments) = match field {
+                models::Field::Column {
+                    column,
+                    fields,
+                    arguments,
+                } => (column, fields, arguments),
+                models::Field::Relationship { .. } => {
+                    return Err(QueryBuilderError::NotSupported("Relationships".to_string()))
+                }
+            };
+
+            if field_name.inner() == "__typename" {
+                if !arguments.is_empty() {
+                    return Err(QueryBuilderError::TypenameArgumentsNotSupported {
+                        object: object_name.clone(),
+                    });
+                }
+                if nested_fields.is_some() {
+                    return Err(QueryBuilderError::TypenameSubselectionNotSupported {
+                        object: object_name.clone(),
+                    });
+                }
+                return Ok(Selection::Field(Field {
+                    position: pos(),
+                    alias: if alias == field_name {
+                        None
+                    } else {
+                        Some(alias.to_string())
+                    },
+                    name: "__typename".to_string(),
+                    arguments: vec![],
+                    directives: vec![],
+                    selection_set: SelectionSet {
+                        span: (pos(), pos()),
+                        items: vec![],
+                    },
+                }));
+            }
+
+            if let Some(concrete_type) = field_name.inner().strip_prefix("on_") {
+                if !arguments.is_empty() {
+                    return Err(QueryBuilderError::PolymorphicFieldArgumentsNotSupported {
+                        object: object_name.clone(),
+                        field: field_name.clone(),
+                    });
+                }
+
+                let concrete_type: TypeName = concrete_type.to_owned().into();
+                if !concrete_types.contains(&concrete_type) {
+                    return Err(QueryBuilderError::PolymorphicFieldNotFound {
+                        object: object_name.clone(),
+                        field: field_name.clone(),
+                    });
+                }
+
+                let requested_subfields = nested_fields
+                    .as_ref()
+                    .and_then(underlying_fields)
+                    .ok_or_else(|| QueryBuilderError::PolymorphicFieldMissingSelection {
+                        object: object_name.clone(),
+                        field: field_name.clone(),
+                    })?;
+
+                let concrete_object_fields =
+                    match configuration.schema.definitions.get(&concrete_type) {
+                        Some(TypeDef::Object { fields, .. }) => fields,
+                        Some(_) | None => {
+                            return Err(QueryBuilderError::ObjectTypeNotFound(concrete_type));
+                        }
+                    };
+                let concrete_variant_fields = interface_exclusive_fields(
+                    concrete_object_fields,
+                    common_fields,
+                );
+
+                let fragment_items = object_selection_items(
+                    &concrete_type,
+                    &concrete_variant_fields,
+                    requested_subfields,
+                    parameters,
+                    configuration,
+                    variables,
+                )?;
+
+                return Ok(Selection::InlineFragment(InlineFragment {
+                    position: pos(),
+                    type_condition: Some(TypeCondition::On(concrete_type.to_string())),
+                    directives: vec![],
+                    selection_set: SelectionSet {
+                        span: (pos(), pos()),
+                        items: fragment_items,
+                    },
+                }));
+            }
+
+            let field_definition = common_fields
+                .and_then(|fields| fields.get(field_name))
+                .ok_or_else(|| QueryBuilderError::PolymorphicFieldNotFound {
+                    object: object_name.clone(),
+                    field: field_name.clone(),
+                })?;
+
+            selection_set_field(
+                &alias.to_string(),
+                field_name,
+                field_arguments(
+                    arguments,
+                    map_query_arg,
+                    field_definition,
+                    parameters,
+                    field_name,
+                    object_name,
+                    variables,
+                )?,
+                nested_fields,
+                field_definition,
+                parameters,
+                configuration,
+                variables,
+            )
+        })
+        .collect()
 }
 
 fn field_arguments<'a, A, M>(
@@ -507,6 +689,27 @@ fn underlying_fields(nested_field: &NestedField) -> Option<&IndexMap<FieldName, 
         NestedField::Object(obj) => Some(&obj.fields),
         NestedField::Array(arr) => underlying_fields(&arr.fields),
         NestedField::Collection(_) => None,
+    }
+}
+
+fn interface_exclusive_fields(
+    concrete_fields: &BTreeMap<FieldName, ObjectFieldDefinition>,
+    common_fields: Option<&BTreeMap<FieldName, ObjectFieldDefinition>>,
+) -> BTreeMap<FieldName, ObjectFieldDefinition> {
+    match common_fields {
+        Some(common_fields) => concrete_fields
+            .iter()
+            .filter(|(field_name, _)| !common_fields.contains_key(*field_name))
+            .map(|(field_name, field_definition)| {
+                (field_name.to_owned(), field_definition.to_owned())
+            })
+            .collect(),
+        None => concrete_fields
+            .iter()
+            .map(|(field_name, field_definition)| {
+                (field_name.to_owned(), field_definition.to_owned())
+            })
+            .collect(),
     }
 }
 

--- a/crates/ndc-graphql/src/query_builder.rs
+++ b/crates/ndc-graphql/src/query_builder.rs
@@ -578,10 +578,8 @@ fn polymorphic_selection_items<'a>(
                             return Err(QueryBuilderError::ObjectTypeNotFound(concrete_type));
                         }
                     };
-                let concrete_variant_fields = interface_exclusive_fields(
-                    concrete_object_fields,
-                    common_fields,
-                );
+                let concrete_variant_fields =
+                    interface_exclusive_fields(concrete_object_fields, common_fields);
 
                 let fragment_items = object_selection_items(
                     &concrete_type,

--- a/crates/ndc-graphql/src/query_builder.rs
+++ b/crates/ndc-graphql/src/query_builder.rs
@@ -17,6 +17,7 @@ use ndc_sdk::models::{
 };
 use std::collections::BTreeMap;
 
+mod coerce;
 pub mod error;
 mod operation_parameters;
 
@@ -85,6 +86,7 @@ pub fn build_mutation_document(
                         &field_name,
                         mutation_type_name,
                         &dummy_variables,
+                        &configuration.schema.definitions,
                     )?,
                     fields,
                     field_definition,
@@ -206,6 +208,7 @@ pub fn build_query_document(
                         &request.collection.to_string().into(),
                         query_type_name,
                         variables,
+                        &configuration.schema.definitions,
                     )?,
                     subfields,
                     root_field_definition,
@@ -246,6 +249,7 @@ pub fn build_query_document(
                     &request.collection.to_string().into(),
                     query_type_name,
                     &dummy_variables,
+                    &configuration.schema.definitions,
                 )?,
                 subfields,
                 root_field_definition,
@@ -480,6 +484,7 @@ fn object_selection_items<'a>(
                     field_name,
                     object_name,
                     variables,
+                    &configuration.schema.definitions,
                 )?,
                 fields,
                 field_definition,
@@ -616,6 +621,7 @@ fn polymorphic_selection_items<'a>(
                     field_name,
                     object_name,
                     variables,
+                    &configuration.schema.definitions,
                 )?,
                 nested_fields,
                 field_definition,
@@ -627,6 +633,7 @@ fn polymorphic_selection_items<'a>(
         .collect()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn field_arguments<'a, A, M>(
     arguments: &BTreeMap<ArgumentName, A>,
     map_argument: M,
@@ -635,6 +642,7 @@ fn field_arguments<'a, A, M>(
     field_name: &FieldName,
     object_name: &TypeName,
     variables: &BTreeMap<VariableName, serde_json::Value>,
+    definitions: &BTreeMap<TypeName, TypeDef>,
 ) -> Result<Vec<(String, Value<'a, String>)>, QueryBuilderError>
 where
     M: Fn(
@@ -657,7 +665,7 @@ where
 
             let value = map_argument(arg, variables)?;
 
-            let value = parameters.insert(name, value, input_type);
+            let value = parameters.insert(name, value, input_type, definitions);
 
             Ok((name.to_string(), value))
         })

--- a/crates/ndc-graphql/src/query_builder/coerce.rs
+++ b/crates/ndc-graphql/src/query_builder/coerce.rs
@@ -1,0 +1,255 @@
+use common::config::schema::{TypeDef, TypeRef};
+use ndc_sdk::models::TypeName;
+use std::collections::BTreeMap;
+
+/// Coerce a `serde_json::Value` to match the expected GraphQL scalar type.
+///
+/// The v3-engine serializes GraphQL values using `value.as_json()`, which loses
+/// type information (e.g. GraphQL `ID` values become JSON strings even when the
+/// input was an integer). This function walks the value recursively according to
+/// the upstream GraphQL type system and coerces leaf scalar values to match.
+pub fn coerce_value(
+    value: serde_json::Value,
+    type_ref: &TypeRef,
+    definitions: &BTreeMap<TypeName, TypeDef>,
+) -> serde_json::Value {
+    match value {
+        serde_json::Value::Null => serde_json::Value::Null,
+        _ => match type_ref {
+            TypeRef::NonNull(inner) => coerce_value(value, inner, definitions),
+            TypeRef::List(inner) => match value {
+                serde_json::Value::Array(items) => serde_json::Value::Array(
+                    items
+                        .into_iter()
+                        .map(|item| coerce_value(item, inner, definitions))
+                        .collect(),
+                ),
+                _ => coerce_value(value, inner, definitions),
+            },
+            TypeRef::Named(name) => coerce_named(value, name, definitions),
+        },
+    }
+}
+
+fn coerce_named(
+    value: serde_json::Value,
+    type_name: &str,
+    definitions: &BTreeMap<TypeName, TypeDef>,
+) -> serde_json::Value {
+    match type_name {
+        "Int" => coerce_to_int(value),
+        "Float" => coerce_to_float(value),
+        "Boolean" => coerce_to_boolean(value),
+        "String" => coerce_to_string(value),
+        "ID" => value, // GraphQL ID accepts both strings and integers
+        _ => {
+            let type_key: TypeName = type_name.to_owned().into();
+            match definitions.get(&type_key) {
+                Some(TypeDef::InputObject { fields, .. }) => coerce_input_object(value, fields, definitions),
+                // enums are already strings; custom scalars and output types pass through
+                _ => value,
+            }
+        }
+    }
+}
+
+fn coerce_input_object(
+    value: serde_json::Value,
+    fields: &BTreeMap<ndc_sdk::models::FieldName, common::config::schema::InputObjectFieldDefinition>,
+    definitions: &BTreeMap<TypeName, TypeDef>,
+) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let coerced: serde_json::Map<String, serde_json::Value> = map
+                .into_iter()
+                .map(|(key, val)| {
+                    let field_name: ndc_sdk::models::FieldName = key.clone().into();
+                    let coerced_val = match fields.get(&field_name) {
+                        Some(field_def) => coerce_value(val, &field_def.r#type, definitions),
+                        None => val, // unknown field: pass through
+                    };
+                    (key, coerced_val)
+                })
+                .collect();
+            serde_json::Value::Object(coerced)
+        }
+        _ => value,
+    }
+}
+
+fn coerce_to_int(value: serde_json::Value) -> serde_json::Value {
+    match &value {
+        serde_json::Value::String(s) => match s.parse::<i64>() {
+            Ok(n) => serde_json::Value::Number(n.into()),
+            Err(_) => value,
+        },
+        _ => value,
+    }
+}
+
+fn coerce_to_float(value: serde_json::Value) -> serde_json::Value {
+    match &value {
+        serde_json::Value::String(s) => s
+            .parse::<f64>()
+            .ok()
+            .and_then(serde_json::Number::from_f64)
+            .map(serde_json::Value::Number)
+            .unwrap_or(value),
+        serde_json::Value::Number(n) => {
+            // Convert integer to float (e.g. 1 -> 1.0)
+            #[allow(clippy::cast_precision_loss)]
+            if let Some(i) = n.as_i64() {
+                serde_json::Number::from_f64(i as f64)
+                    .map(serde_json::Value::Number)
+                    .unwrap_or(value)
+            } else {
+                value
+            }
+        }
+        _ => value,
+    }
+}
+
+fn coerce_to_boolean(value: serde_json::Value) -> serde_json::Value {
+    match &value {
+        serde_json::Value::String(s) => match s.as_str() {
+            "true" => serde_json::Value::Bool(true),
+            "false" => serde_json::Value::Bool(false),
+            _ => value,
+        },
+        _ => value,
+    }
+}
+
+fn coerce_to_string(value: serde_json::Value) -> serde_json::Value {
+    match &value {
+        serde_json::Value::Number(n) => serde_json::Value::String(n.to_string()),
+        serde_json::Value::Bool(b) => serde_json::Value::String(b.to_string()),
+        _ => value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn empty_definitions() -> BTreeMap<TypeName, TypeDef> {
+        BTreeMap::new()
+    }
+
+    #[test]
+    fn coerce_string_to_int() {
+        let result = coerce_value(json!("42"), &TypeRef::Named("Int".to_string()), &empty_definitions());
+        assert_eq!(result, json!(42));
+    }
+
+    #[test]
+    fn coerce_int_stays_int() {
+        let result = coerce_value(json!(42), &TypeRef::Named("Int".to_string()), &empty_definitions());
+        assert_eq!(result, json!(42));
+    }
+
+    #[test]
+    fn coerce_string_to_float() {
+        let result = coerce_value(json!("1.5"), &TypeRef::Named("Float".to_string()), &empty_definitions());
+        assert_eq!(result, json!(1.5));
+    }
+
+    #[test]
+    fn coerce_int_to_float() {
+        let result = coerce_value(json!(1), &TypeRef::Named("Float".to_string()), &empty_definitions());
+        assert_eq!(result, json!(1.0));
+    }
+
+    #[test]
+    fn coerce_string_to_boolean() {
+        let result = coerce_value(json!("true"), &TypeRef::Named("Boolean".to_string()), &empty_definitions());
+        assert_eq!(result, json!(true));
+
+        let result = coerce_value(json!("false"), &TypeRef::Named("Boolean".to_string()), &empty_definitions());
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn coerce_number_to_string() {
+        let result = coerce_value(json!(42), &TypeRef::Named("String".to_string()), &empty_definitions());
+        assert_eq!(result, json!("42"));
+    }
+
+    #[test]
+    fn coerce_id_passes_through() {
+        let result = coerce_value(json!(42), &TypeRef::Named("ID".to_string()), &empty_definitions());
+        assert_eq!(result, json!(42));
+
+        let result = coerce_value(json!("42"), &TypeRef::Named("ID".to_string()), &empty_definitions());
+        assert_eq!(result, json!("42"));
+    }
+
+    #[test]
+    fn coerce_null_passes_through() {
+        let result = coerce_value(json!(null), &TypeRef::Named("Int".to_string()), &empty_definitions());
+        assert_eq!(result, json!(null));
+    }
+
+    #[test]
+    fn coerce_nonnull_unwraps() {
+        let type_ref = TypeRef::NonNull(Box::new(TypeRef::Named("Int".to_string())));
+        let result = coerce_value(json!("42"), &type_ref, &empty_definitions());
+        assert_eq!(result, json!(42));
+    }
+
+    #[test]
+    fn coerce_list_elements() {
+        let type_ref = TypeRef::List(Box::new(TypeRef::Named("Int".to_string())));
+        let result = coerce_value(json!(["1", "2", 3]), &type_ref, &empty_definitions());
+        assert_eq!(result, json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn coerce_input_object_fields() {
+        let mut fields = BTreeMap::new();
+        fields.insert(
+            "_gt".to_string().into(),
+            common::config::schema::InputObjectFieldDefinition {
+                r#type: TypeRef::Named("Int".to_string()),
+                description: None,
+            },
+        );
+
+        let mut definitions = BTreeMap::new();
+        definitions.insert(
+            "Int_comparison_exp".to_string().into(),
+            TypeDef::InputObject {
+                fields,
+                description: None,
+            },
+        );
+
+        let type_ref = TypeRef::Named("Int_comparison_exp".to_string());
+        let result = coerce_value(json!({"_gt": "5"}), &type_ref, &definitions);
+        assert_eq!(result, json!({"_gt": 5}));
+    }
+
+    #[test]
+    fn coerce_custom_scalar_passes_through() {
+        let mut definitions = BTreeMap::new();
+        definitions.insert(
+            "DateTime".to_string().into(),
+            TypeDef::Scalar { description: None },
+        );
+
+        let result = coerce_value(
+            json!("2024-01-01"),
+            &TypeRef::Named("DateTime".to_string()),
+            &definitions,
+        );
+        assert_eq!(result, json!("2024-01-01"));
+    }
+
+    #[test]
+    fn coerce_unparseable_string_passes_through() {
+        let result = coerce_value(json!("not_a_number"), &TypeRef::Named("Int".to_string()), &empty_definitions());
+        assert_eq!(result, json!("not_a_number"));
+    }
+}

--- a/crates/ndc-graphql/src/query_builder/coerce.rs
+++ b/crates/ndc-graphql/src/query_builder/coerce.rs
@@ -45,7 +45,9 @@ fn coerce_named(
         _ => {
             let type_key: TypeName = type_name.to_owned().into();
             match definitions.get(&type_key) {
-                Some(TypeDef::InputObject { fields, .. }) => coerce_input_object(value, fields, definitions),
+                Some(TypeDef::InputObject { fields, .. }) => {
+                    coerce_input_object(value, fields, definitions)
+                }
                 // enums are already strings; custom scalars and output types pass through
                 _ => value,
             }
@@ -55,7 +57,10 @@ fn coerce_named(
 
 fn coerce_input_object(
     value: serde_json::Value,
-    fields: &BTreeMap<ndc_sdk::models::FieldName, common::config::schema::InputObjectFieldDefinition>,
+    fields: &BTreeMap<
+        ndc_sdk::models::FieldName,
+        common::config::schema::InputObjectFieldDefinition,
+    >,
     definitions: &BTreeMap<TypeName, TypeDef>,
 ) -> serde_json::Value {
     match value {
@@ -140,55 +145,95 @@ mod tests {
 
     #[test]
     fn coerce_string_to_int() {
-        let result = coerce_value(json!("42"), &TypeRef::Named("Int".to_string()), &empty_definitions());
+        let result = coerce_value(
+            json!("42"),
+            &TypeRef::Named("Int".to_string()),
+            &empty_definitions(),
+        );
         assert_eq!(result, json!(42));
     }
 
     #[test]
     fn coerce_int_stays_int() {
-        let result = coerce_value(json!(42), &TypeRef::Named("Int".to_string()), &empty_definitions());
+        let result = coerce_value(
+            json!(42),
+            &TypeRef::Named("Int".to_string()),
+            &empty_definitions(),
+        );
         assert_eq!(result, json!(42));
     }
 
     #[test]
     fn coerce_string_to_float() {
-        let result = coerce_value(json!("1.5"), &TypeRef::Named("Float".to_string()), &empty_definitions());
+        let result = coerce_value(
+            json!("1.5"),
+            &TypeRef::Named("Float".to_string()),
+            &empty_definitions(),
+        );
         assert_eq!(result, json!(1.5));
     }
 
     #[test]
     fn coerce_int_to_float() {
-        let result = coerce_value(json!(1), &TypeRef::Named("Float".to_string()), &empty_definitions());
+        let result = coerce_value(
+            json!(1),
+            &TypeRef::Named("Float".to_string()),
+            &empty_definitions(),
+        );
         assert_eq!(result, json!(1.0));
     }
 
     #[test]
     fn coerce_string_to_boolean() {
-        let result = coerce_value(json!("true"), &TypeRef::Named("Boolean".to_string()), &empty_definitions());
+        let result = coerce_value(
+            json!("true"),
+            &TypeRef::Named("Boolean".to_string()),
+            &empty_definitions(),
+        );
         assert_eq!(result, json!(true));
 
-        let result = coerce_value(json!("false"), &TypeRef::Named("Boolean".to_string()), &empty_definitions());
+        let result = coerce_value(
+            json!("false"),
+            &TypeRef::Named("Boolean".to_string()),
+            &empty_definitions(),
+        );
         assert_eq!(result, json!(false));
     }
 
     #[test]
     fn coerce_number_to_string() {
-        let result = coerce_value(json!(42), &TypeRef::Named("String".to_string()), &empty_definitions());
+        let result = coerce_value(
+            json!(42),
+            &TypeRef::Named("String".to_string()),
+            &empty_definitions(),
+        );
         assert_eq!(result, json!("42"));
     }
 
     #[test]
     fn coerce_id_passes_through() {
-        let result = coerce_value(json!(42), &TypeRef::Named("ID".to_string()), &empty_definitions());
+        let result = coerce_value(
+            json!(42),
+            &TypeRef::Named("ID".to_string()),
+            &empty_definitions(),
+        );
         assert_eq!(result, json!(42));
 
-        let result = coerce_value(json!("42"), &TypeRef::Named("ID".to_string()), &empty_definitions());
+        let result = coerce_value(
+            json!("42"),
+            &TypeRef::Named("ID".to_string()),
+            &empty_definitions(),
+        );
         assert_eq!(result, json!("42"));
     }
 
     #[test]
     fn coerce_null_passes_through() {
-        let result = coerce_value(json!(null), &TypeRef::Named("Int".to_string()), &empty_definitions());
+        let result = coerce_value(
+            json!(null),
+            &TypeRef::Named("Int".to_string()),
+            &empty_definitions(),
+        );
         assert_eq!(result, json!(null));
     }
 
@@ -249,7 +294,11 @@ mod tests {
 
     #[test]
     fn coerce_unparseable_string_passes_through() {
-        let result = coerce_value(json!("not_a_number"), &TypeRef::Named("Int".to_string()), &empty_definitions());
+        let result = coerce_value(
+            json!("not_a_number"),
+            &TypeRef::Named("Int".to_string()),
+            &empty_definitions(),
+        );
         assert_eq!(result, json!("not_a_number"));
     }
 }

--- a/crates/ndc-graphql/src/query_builder/error.rs
+++ b/crates/ndc-graphql/src/query_builder/error.rs
@@ -24,6 +24,24 @@ pub enum QueryBuilderError {
         object: TypeName,
         field: FieldName,
     },
+    PolymorphicFieldNotFound {
+        object: TypeName,
+        field: FieldName,
+    },
+    PolymorphicFieldMissingSelection {
+        object: TypeName,
+        field: FieldName,
+    },
+    PolymorphicFieldArgumentsNotSupported {
+        object: TypeName,
+        field: FieldName,
+    },
+    TypenameArgumentsNotSupported {
+        object: TypeName,
+    },
+    TypenameSubselectionNotSupported {
+        object: TypeName,
+    },
     InputObjectFieldNotFound {
         input_object: TypeName,
         field: FieldName,
@@ -73,6 +91,36 @@ impl Display for QueryBuilderError {
             }
             QueryBuilderError::ObjectFieldNotFound { object, field } => {
                 write!(f, "Field {field} not found in Object Type {object}")
+            }
+            QueryBuilderError::PolymorphicFieldNotFound { object, field } => {
+                write!(
+                    f,
+                    "Field {field} is not a valid tagged variant field in polymorphic type {object}"
+                )
+            }
+            QueryBuilderError::PolymorphicFieldMissingSelection { object, field } => {
+                write!(
+                    f,
+                    "Field {field} in polymorphic type {object} requires a nested object selection"
+                )
+            }
+            QueryBuilderError::PolymorphicFieldArgumentsNotSupported { object, field } => {
+                write!(
+                    f,
+                    "Arguments are not supported for polymorphic tagged field {object}.{field}"
+                )
+            }
+            QueryBuilderError::TypenameArgumentsNotSupported { object } => {
+                write!(
+                    f,
+                    "Arguments are not supported for polymorphic field {object}.__typename"
+                )
+            }
+            QueryBuilderError::TypenameSubselectionNotSupported { object } => {
+                write!(
+                    f,
+                    "Field {object}.__typename cannot have a nested selection set"
+                )
             }
             QueryBuilderError::InputObjectFieldNotFound {
                 input_object,

--- a/crates/ndc-graphql/src/query_builder/operation_parameters.rs
+++ b/crates/ndc-graphql/src/query_builder/operation_parameters.rs
@@ -1,11 +1,13 @@
 use std::collections::BTreeMap;
 
-use common::config::schema::TypeRef;
+use common::config::schema::{TypeDef, TypeRef};
 use graphql_parser::{
     query::{Type, Value, VariableDefinition},
     Pos,
 };
-use ndc_sdk::models::ArgumentName;
+use ndc_sdk::models::{ArgumentName, TypeName};
+
+use super::coerce::coerce_value;
 
 pub struct OperationParameters {
     namespace: String,
@@ -26,9 +28,12 @@ impl<'c> OperationParameters {
         name: &ArgumentName,
         value: serde_json::Value,
         r#type: &TypeRef,
+        definitions: &BTreeMap<TypeName, TypeDef>,
     ) -> Value<'c, String> {
         let name = format!("{}arg_{}_{}", self.namespace, self.parameter_index, name);
         self.parameter_index += 1;
+
+        let value = coerce_value(value, r#type, definitions);
 
         self.parameters
             .insert(name.clone(), (value, r#type.to_owned()));

--- a/crates/ndc-graphql/tests/config-1/queries/06_scalar_coercion.request.json
+++ b/crates/ndc-graphql/tests/config-1/queries/06_scalar_coercion.request.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "_query_request.schema.json",
+    "collection": "Album",
+    "query": {
+        "fields": {
+            "__value": {
+                "type": "column",
+                "column": "__value",
+                "fields": {
+                    "type": "array",
+                    "fields": {
+                        "type": "object",
+                        "fields": {
+                            "AlbumId": {
+                                "type": "column",
+                                "column": "AlbumId",
+                                "fields": null
+                            },
+                            "Title": {
+                                "type": "column",
+                                "column": "Title",
+                                "fields": null
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "arguments": {
+        "limit": {
+            "type": "literal",
+            "value": "20"
+        },
+        "where": {
+            "type": "literal",
+            "value": {
+                "AlbumId": {
+                    "_gt": "5"
+                }
+            }
+        }
+    },
+    "collection_relationships": {}
+}

--- a/crates/ndc-graphql/tests/config-4/configuration/configuration.json
+++ b/crates/ndc-graphql/tests/config-4/configuration/configuration.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "configuration.schema.json",
+  "introspection": {
+    "endpoint": {
+      "valueFromEnv": "GRAPHQL_ENDPOINT"
+    },
+    "headers": {}
+  },
+  "execution": {
+    "endpoint": {
+      "valueFromEnv": "GRAPHQL_ENDPOINT"
+    },
+    "headers": {}
+  }
+}

--- a/crates/ndc-graphql/tests/config-4/configuration/configuration.schema.json
+++ b/crates/ndc-graphql/tests/config-4/configuration/configuration.schema.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ServerConfigFile",
+  "type": "object",
+  "required": [
+    "$schema",
+    "execution",
+    "introspection"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "introspection": {
+      "description": "Connection Configuration for introspection.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionConfigFile"
+        }
+      ]
+    },
+    "execution": {
+      "description": "Connection configuration for query execution.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionConfigFile"
+        }
+      ]
+    },
+    "request": {
+      "description": "Optional configuration for requests.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RequestConfigFile"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "response": {
+      "description": "Optional configuration for responses.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ResponseConfigFile"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "ConnectionConfigFile": {
+      "type": "object",
+      "required": [
+        "endpoint"
+      ],
+      "properties": {
+        "endpoint": {
+          "description": "Target GraphQL endpoint URL",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConfigValue"
+            }
+          ]
+        },
+        "headers": {
+          "description": "Static headers to include with each request",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ConfigValue"
+          }
+        }
+      }
+    },
+    "ConfigValue": {
+      "oneOf": [
+        {
+          "description": "A static string value",
+          "type": "object",
+          "required": [
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "A reference to an environment variable, from which the value will be read at runtime",
+          "type": "object",
+          "required": [
+            "valueFromEnv"
+          ],
+          "properties": {
+            "valueFromEnv": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "RequestConfigFile": {
+      "type": "object",
+      "properties": {
+        "headersArgument": {
+          "description": "Name of the headers argument. Must not conflict with any arguments of root fields in the target schema. Defaults to \"_headers\", set to a different value if there is a conflict.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "headersTypeName": {
+          "description": "Name of the headers argument type. Must not conflict with other types in the target schema. Defaults to \"_HeaderMap\", set to a different value if there is a conflict.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "forwardHeaders": {
+          "description": "List of headers to forward from the request. Defaults to [], AKA no headers/disabled. Supports glob patterns eg. \"X-Hasura-*\". Enabling this requires additional configuration on the ddn side, see docs for more.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ResponseConfigFile": {
+      "type": "object",
+      "properties": {
+        "headersField": {
+          "description": "Name of the headers field in the response type. Defaults to \"headers\".",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "responseField": {
+          "description": "Name of the response field in the response type. Defaults to \"response\".",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "typeNamePrefix": {
+          "description": "Prefix for response type names. Defaults to \"_\". Generated response type names must be unique once prefix and suffix are applied.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "typeNameSuffix": {
+          "description": "Suffix for response type names. Defaults to \"Response\". Generated response type names must be unique once prefix and suffix are applied.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "forwardHeaders": {
+          "description": "List of headers to forward from the response. Defaults to [], AKA no headers/disabled. Supports glob patterns eg. \"X-Hasura-*\". Enabling this requires additional configuration on the ddn side, see docs for more.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/ndc-graphql/tests/config-4/configuration/schema.graphql
+++ b/crates/ndc-graphql/tests/config-4/configuration/schema.graphql
@@ -1,0 +1,32 @@
+schema {
+  query: Query
+}
+
+scalar ID
+scalar String
+
+type Query {
+  getAccountById(id: ID!): Account
+}
+
+type Account {
+  id: ID!
+  relationship: PartyAccountRelationship!
+  altRelationship: PartyRelationshipUnion
+}
+
+interface PartyAccountRelationship {
+  relId: ID!
+}
+
+type PersonRelationship implements PartyAccountRelationship {
+  relId: ID!
+  personName: String
+}
+
+type OrganizationRelationship implements PartyAccountRelationship {
+  relId: ID!
+  orgName: String
+}
+
+union PartyRelationshipUnion = PersonRelationship | OrganizationRelationship

--- a/crates/ndc-graphql/tests/config-4/mutations/_mutation_request.schema.json
+++ b/crates/ndc-graphql/tests/config-4/mutations/_mutation_request.schema.json
@@ -1,0 +1,1020 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Mutation Request",
+  "type": "object",
+  "required": [
+    "collection_relationships",
+    "operations"
+  ],
+  "properties": {
+    "operations": {
+      "description": "The mutation operations to perform",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/MutationOperation"
+      }
+    },
+    "collection_relationships": {
+      "description": "The relationships between collections involved in the entire mutation request",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/Relationship"
+      }
+    }
+  },
+  "definitions": {
+    "MutationOperation": {
+      "title": "Mutation Operation",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "arguments",
+            "name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "procedure"
+              ]
+            },
+            "name": {
+              "description": "The name of a procedure",
+              "type": "string"
+            },
+            "arguments": {
+              "description": "Any named procedure arguments",
+              "type": "object",
+              "additionalProperties": true
+            },
+            "fields": {
+              "description": "The fields to return from the result, or null to return everything",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NestedField"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "NestedField": {
+      "title": "NestedField",
+      "oneOf": [
+        {
+          "title": "NestedObject",
+          "type": "object",
+          "required": [
+            "fields",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "object"
+              ]
+            },
+            "fields": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Field"
+              }
+            }
+          }
+        },
+        {
+          "title": "NestedArray",
+          "type": "object",
+          "required": [
+            "fields",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "array"
+              ]
+            },
+            "fields": {
+              "$ref": "#/definitions/NestedField"
+            }
+          }
+        }
+      ]
+    },
+    "Field": {
+      "title": "Field",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "column",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "column"
+              ]
+            },
+            "column": {
+              "type": "string"
+            },
+            "fields": {
+              "description": "When the type of the column is a (possibly-nullable) array or object, the caller can request a subset of the complete column data, by specifying fields to fetch here. If omitted, the column data will be fetched in full.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NestedField"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "arguments": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "arguments",
+            "query",
+            "relationship",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "relationship"
+              ]
+            },
+            "query": {
+              "$ref": "#/definitions/Query"
+            },
+            "relationship": {
+              "description": "The name of the relationship to follow for the subquery",
+              "type": "string"
+            },
+            "arguments": {
+              "description": "Values to be provided to any collection arguments",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/RelationshipArgument"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Argument": {
+      "title": "Argument",
+      "oneOf": [
+        {
+          "description": "The argument is provided by reference to a variable",
+          "type": "object",
+          "required": [
+            "name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "variable"
+              ]
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "The argument is provided as a literal value",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "literal"
+              ]
+            },
+            "value": true
+          }
+        }
+      ]
+    },
+    "Query": {
+      "title": "Query",
+      "type": "object",
+      "properties": {
+        "aggregates": {
+          "description": "Aggregate fields of the query",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/Aggregate"
+          }
+        },
+        "fields": {
+          "description": "Fields of the query",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/Field"
+          }
+        },
+        "limit": {
+          "description": "Optionally limit to N results",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "offset": {
+          "description": "Optionally offset from the Nth result",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "order_by": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OrderBy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "predicate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expression"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "Aggregate": {
+      "title": "Aggregate",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "column",
+            "distinct",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "column_count"
+              ]
+            },
+            "column": {
+              "description": "The column to apply the count aggregate function to",
+              "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "distinct": {
+              "description": "Whether or not only distinct items should be counted",
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "column",
+            "function",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "single_column"
+              ]
+            },
+            "column": {
+              "description": "The column to apply the aggregation function to",
+              "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "function": {
+              "description": "Single column aggregate function name.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "star_count"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "OrderBy": {
+      "title": "Order By",
+      "type": "object",
+      "required": [
+        "elements"
+      ],
+      "properties": {
+        "elements": {
+          "description": "The elements to order by, in priority order",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OrderByElement"
+          }
+        }
+      }
+    },
+    "OrderByElement": {
+      "title": "Order By Element",
+      "type": "object",
+      "required": [
+        "order_direction",
+        "target"
+      ],
+      "properties": {
+        "order_direction": {
+          "$ref": "#/definitions/OrderDirection"
+        },
+        "target": {
+          "$ref": "#/definitions/OrderByTarget"
+        }
+      }
+    },
+    "OrderDirection": {
+      "title": "Order Direction",
+      "type": "string",
+      "enum": [
+        "asc",
+        "desc"
+      ]
+    },
+    "OrderByTarget": {
+      "title": "Order By Target",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "name",
+            "path",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "column"
+              ]
+            },
+            "name": {
+              "description": "The name of the column",
+              "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "path": {
+              "description": "Any relationships to traverse to reach this column",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PathElement"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "column",
+            "function",
+            "path",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "single_column_aggregate"
+              ]
+            },
+            "column": {
+              "description": "The column to apply the aggregation function to",
+              "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "function": {
+              "description": "Single column aggregate function name.",
+              "type": "string"
+            },
+            "path": {
+              "description": "Non-empty collection of relationships to traverse",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PathElement"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "path",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "star_count_aggregate"
+              ]
+            },
+            "path": {
+              "description": "Non-empty collection of relationships to traverse",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PathElement"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "PathElement": {
+      "title": "Path Element",
+      "type": "object",
+      "required": [
+        "arguments",
+        "relationship"
+      ],
+      "properties": {
+        "relationship": {
+          "description": "The name of the relationship to follow",
+          "type": "string"
+        },
+        "arguments": {
+          "description": "Values to be provided to any collection arguments",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/RelationshipArgument"
+          }
+        },
+        "predicate": {
+          "description": "A predicate expression to apply to the target collection",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expression"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RelationshipArgument": {
+      "title": "Relationship Argument",
+      "oneOf": [
+        {
+          "description": "The argument is provided by reference to a variable",
+          "type": "object",
+          "required": [
+            "name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "variable"
+              ]
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "The argument is provided as a literal value",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "literal"
+              ]
+            },
+            "value": true
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "column"
+              ]
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "Expression": {
+      "title": "Expression",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "expressions",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "and"
+              ]
+            },
+            "expressions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Expression"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expressions",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "or"
+              ]
+            },
+            "expressions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Expression"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expression",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "not"
+              ]
+            },
+            "expression": {
+              "$ref": "#/definitions/Expression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "column",
+            "operator",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "unary_comparison_operator"
+              ]
+            },
+            "column": {
+              "$ref": "#/definitions/ComparisonTarget"
+            },
+            "operator": {
+              "$ref": "#/definitions/UnaryComparisonOperator"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "column",
+            "operator",
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "binary_comparison_operator"
+              ]
+            },
+            "column": {
+              "$ref": "#/definitions/ComparisonTarget"
+            },
+            "operator": {
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/definitions/ComparisonValue"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "in_collection",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "exists"
+              ]
+            },
+            "in_collection": {
+              "$ref": "#/definitions/ExistsInCollection"
+            },
+            "predicate": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "ComparisonTarget": {
+      "title": "Comparison Target",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "name",
+            "path",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "column"
+              ]
+            },
+            "name": {
+              "description": "The name of the column",
+              "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "path": {
+              "description": "Any relationships to traverse to reach this column",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PathElement"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "root_collection_column"
+              ]
+            },
+            "name": {
+              "description": "The name of the column",
+              "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "UnaryComparisonOperator": {
+      "title": "Unary Comparison Operator",
+      "type": "string",
+      "enum": [
+        "is_null"
+      ]
+    },
+    "ComparisonValue": {
+      "title": "Comparison Value",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "column",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "column"
+              ]
+            },
+            "column": {
+              "$ref": "#/definitions/ComparisonTarget"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "scalar"
+              ]
+            },
+            "value": true
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "variable"
+              ]
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "ExistsInCollection": {
+      "title": "Exists In Collection",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "arguments",
+            "relationship",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "related"
+              ]
+            },
+            "relationship": {
+              "type": "string"
+            },
+            "arguments": {
+              "description": "Values to be provided to any collection arguments",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/RelationshipArgument"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "arguments",
+            "collection",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "unrelated"
+              ]
+            },
+            "collection": {
+              "description": "The name of a collection",
+              "type": "string"
+            },
+            "arguments": {
+              "description": "Values to be provided to any collection arguments",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/RelationshipArgument"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "column_name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "nested_collection"
+              ]
+            },
+            "column_name": {
+              "type": "string"
+            },
+            "arguments": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
+            },
+            "field_path": {
+              "description": "Path to a nested collection via object columns",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Relationship": {
+      "title": "Relationship",
+      "type": "object",
+      "required": [
+        "arguments",
+        "column_mapping",
+        "relationship_type",
+        "target_collection"
+      ],
+      "properties": {
+        "column_mapping": {
+          "description": "A mapping between columns on the source collection to columns on the target collection",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "relationship_type": {
+          "$ref": "#/definitions/RelationshipType"
+        },
+        "target_collection": {
+          "description": "The name of a collection",
+          "type": "string"
+        },
+        "arguments": {
+          "description": "Values to be provided to any collection arguments",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/RelationshipArgument"
+          }
+        }
+      }
+    },
+    "RelationshipType": {
+      "title": "Relationship Type",
+      "type": "string",
+      "enum": [
+        "object",
+        "array"
+      ]
+    }
+  }
+}

--- a/crates/ndc-graphql/tests/config-4/queries/01_polymorphic_query.request.json
+++ b/crates/ndc-graphql/tests/config-4/queries/01_polymorphic_query.request.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "_query_request.schema.json",
+  "collection": "getAccountById",
+  "query": {
+    "fields": {
+      "__value": {
+        "type": "column",
+        "column": "__value",
+        "fields": {
+          "type": "object",
+          "fields": {
+            "id": {
+              "type": "column",
+              "column": "id",
+              "fields": null
+            },
+            "relationship": {
+              "type": "column",
+              "column": "relationship",
+              "fields": {
+                "type": "object",
+                "fields": {
+                  "__typename": {
+                    "type": "column",
+                    "column": "__typename",
+                    "fields": null
+                  },
+                  "relId": {
+                    "type": "column",
+                    "column": "relId",
+                    "fields": null
+                  },
+                  "on_PersonRelationship": {
+                    "type": "column",
+                    "column": "on_PersonRelationship",
+                    "fields": {
+                      "type": "object",
+                      "fields": {
+                        "personName": {
+                          "type": "column",
+                          "column": "personName",
+                          "fields": null
+                        }
+                      }
+                    }
+                  },
+                  "on_OrganizationRelationship": {
+                    "type": "column",
+                    "column": "on_OrganizationRelationship",
+                    "fields": {
+                      "type": "object",
+                      "fields": {
+                        "orgName": {
+                          "type": "column",
+                          "column": "orgName",
+                          "fields": null
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "altRelationship": {
+              "type": "column",
+              "column": "altRelationship",
+              "fields": {
+                "type": "object",
+                "fields": {
+                  "__typename": {
+                    "type": "column",
+                    "column": "__typename",
+                    "fields": null
+                  },
+                  "on_PersonRelationship": {
+                    "type": "column",
+                    "column": "on_PersonRelationship",
+                    "fields": {
+                      "type": "object",
+                      "fields": {
+                        "relId": {
+                          "type": "column",
+                          "column": "relId",
+                          "fields": null
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "arguments": {
+    "id": {
+      "type": "literal",
+      "value": "acct-1"
+    }
+  },
+  "collection_relationships": {}
+}

--- a/crates/ndc-graphql/tests/config-4/queries/_query_request.schema.json
+++ b/crates/ndc-graphql/tests/config-4/queries/_query_request.schema.json
@@ -1,0 +1,1005 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Query Request",
+  "description": "This is the request body of the query POST endpoint",
+  "type": "object",
+  "required": [
+    "arguments",
+    "collection",
+    "collection_relationships",
+    "query"
+  ],
+  "properties": {
+    "collection": {
+      "description": "The name of a collection",
+      "type": "string"
+    },
+    "query": {
+      "description": "The query syntax tree",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Query"
+        }
+      ]
+    },
+    "arguments": {
+      "description": "Values to be provided to any collection arguments",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/Argument"
+      }
+    },
+    "collection_relationships": {
+      "description": "Any relationships between collections involved in the query request",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/Relationship"
+      }
+    },
+    "variables": {
+      "description": "One set of named variables for each rowset to fetch. Each variable set should be subtituted in turn, and a fresh set of rows returned.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    }
+  },
+  "definitions": {
+    "Query": {
+      "title": "Query",
+      "type": "object",
+      "properties": {
+        "aggregates": {
+          "description": "Aggregate fields of the query",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/Aggregate"
+          }
+        },
+        "fields": {
+          "description": "Fields of the query",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/Field"
+          }
+        },
+        "limit": {
+          "description": "Optionally limit to N results",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "offset": {
+          "description": "Optionally offset from the Nth result",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "order_by": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OrderBy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "predicate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expression"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "Aggregate": {
+      "title": "Aggregate",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "column",
+            "distinct",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "column_count"
+              ]
+            },
+            "column": {
+              "description": "The column to apply the count aggregate function to",
+              "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "distinct": {
+              "description": "Whether or not only distinct items should be counted",
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "column",
+            "function",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "single_column"
+              ]
+            },
+            "column": {
+              "description": "The column to apply the aggregation function to",
+              "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "function": {
+              "description": "Single column aggregate function name.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "star_count"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Field": {
+      "title": "Field",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "column",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "column"
+              ]
+            },
+            "column": {
+              "type": "string"
+            },
+            "fields": {
+              "description": "When the type of the column is a (possibly-nullable) array or object, the caller can request a subset of the complete column data, by specifying fields to fetch here. If omitted, the column data will be fetched in full.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NestedField"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "arguments": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "arguments",
+            "query",
+            "relationship",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "relationship"
+              ]
+            },
+            "query": {
+              "$ref": "#/definitions/Query"
+            },
+            "relationship": {
+              "description": "The name of the relationship to follow for the subquery",
+              "type": "string"
+            },
+            "arguments": {
+              "description": "Values to be provided to any collection arguments",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/RelationshipArgument"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "NestedField": {
+      "title": "NestedField",
+      "oneOf": [
+        {
+          "title": "NestedObject",
+          "type": "object",
+          "required": [
+            "fields",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "object"
+              ]
+            },
+            "fields": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Field"
+              }
+            }
+          }
+        },
+        {
+          "title": "NestedArray",
+          "type": "object",
+          "required": [
+            "fields",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "array"
+              ]
+            },
+            "fields": {
+              "$ref": "#/definitions/NestedField"
+            }
+          }
+        }
+      ]
+    },
+    "Argument": {
+      "title": "Argument",
+      "oneOf": [
+        {
+          "description": "The argument is provided by reference to a variable",
+          "type": "object",
+          "required": [
+            "name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "variable"
+              ]
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "The argument is provided as a literal value",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "literal"
+              ]
+            },
+            "value": true
+          }
+        }
+      ]
+    },
+    "RelationshipArgument": {
+      "title": "Relationship Argument",
+      "oneOf": [
+        {
+          "description": "The argument is provided by reference to a variable",
+          "type": "object",
+          "required": [
+            "name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "variable"
+              ]
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "The argument is provided as a literal value",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "literal"
+              ]
+            },
+            "value": true
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "column"
+              ]
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "OrderBy": {
+      "title": "Order By",
+      "type": "object",
+      "required": [
+        "elements"
+      ],
+      "properties": {
+        "elements": {
+          "description": "The elements to order by, in priority order",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OrderByElement"
+          }
+        }
+      }
+    },
+    "OrderByElement": {
+      "title": "Order By Element",
+      "type": "object",
+      "required": [
+        "order_direction",
+        "target"
+      ],
+      "properties": {
+        "order_direction": {
+          "$ref": "#/definitions/OrderDirection"
+        },
+        "target": {
+          "$ref": "#/definitions/OrderByTarget"
+        }
+      }
+    },
+    "OrderDirection": {
+      "title": "Order Direction",
+      "type": "string",
+      "enum": [
+        "asc",
+        "desc"
+      ]
+    },
+    "OrderByTarget": {
+      "title": "Order By Target",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "name",
+            "path",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "column"
+              ]
+            },
+            "name": {
+              "description": "The name of the column",
+              "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "path": {
+              "description": "Any relationships to traverse to reach this column",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PathElement"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "column",
+            "function",
+            "path",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "single_column_aggregate"
+              ]
+            },
+            "column": {
+              "description": "The column to apply the aggregation function to",
+              "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "function": {
+              "description": "Single column aggregate function name.",
+              "type": "string"
+            },
+            "path": {
+              "description": "Non-empty collection of relationships to traverse",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PathElement"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "path",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "star_count_aggregate"
+              ]
+            },
+            "path": {
+              "description": "Non-empty collection of relationships to traverse",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PathElement"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "PathElement": {
+      "title": "Path Element",
+      "type": "object",
+      "required": [
+        "arguments",
+        "relationship"
+      ],
+      "properties": {
+        "relationship": {
+          "description": "The name of the relationship to follow",
+          "type": "string"
+        },
+        "arguments": {
+          "description": "Values to be provided to any collection arguments",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/RelationshipArgument"
+          }
+        },
+        "predicate": {
+          "description": "A predicate expression to apply to the target collection",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expression"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "Expression": {
+      "title": "Expression",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "expressions",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "and"
+              ]
+            },
+            "expressions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Expression"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expressions",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "or"
+              ]
+            },
+            "expressions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Expression"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expression",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "not"
+              ]
+            },
+            "expression": {
+              "$ref": "#/definitions/Expression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "column",
+            "operator",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "unary_comparison_operator"
+              ]
+            },
+            "column": {
+              "$ref": "#/definitions/ComparisonTarget"
+            },
+            "operator": {
+              "$ref": "#/definitions/UnaryComparisonOperator"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "column",
+            "operator",
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "binary_comparison_operator"
+              ]
+            },
+            "column": {
+              "$ref": "#/definitions/ComparisonTarget"
+            },
+            "operator": {
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/definitions/ComparisonValue"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "in_collection",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "exists"
+              ]
+            },
+            "in_collection": {
+              "$ref": "#/definitions/ExistsInCollection"
+            },
+            "predicate": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "ComparisonTarget": {
+      "title": "Comparison Target",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "name",
+            "path",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "column"
+              ]
+            },
+            "name": {
+              "description": "The name of the column",
+              "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "path": {
+              "description": "Any relationships to traverse to reach this column",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PathElement"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "root_collection_column"
+              ]
+            },
+            "name": {
+              "description": "The name of the column",
+              "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "UnaryComparisonOperator": {
+      "title": "Unary Comparison Operator",
+      "type": "string",
+      "enum": [
+        "is_null"
+      ]
+    },
+    "ComparisonValue": {
+      "title": "Comparison Value",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "column",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "column"
+              ]
+            },
+            "column": {
+              "$ref": "#/definitions/ComparisonTarget"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "scalar"
+              ]
+            },
+            "value": true
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "variable"
+              ]
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "ExistsInCollection": {
+      "title": "Exists In Collection",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "arguments",
+            "relationship",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "related"
+              ]
+            },
+            "relationship": {
+              "type": "string"
+            },
+            "arguments": {
+              "description": "Values to be provided to any collection arguments",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/RelationshipArgument"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "arguments",
+            "collection",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "unrelated"
+              ]
+            },
+            "collection": {
+              "description": "The name of a collection",
+              "type": "string"
+            },
+            "arguments": {
+              "description": "Values to be provided to any collection arguments",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/RelationshipArgument"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "column_name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "nested_collection"
+              ]
+            },
+            "column_name": {
+              "type": "string"
+            },
+            "arguments": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
+            },
+            "field_path": {
+              "description": "Path to a nested collection via object columns",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Relationship": {
+      "title": "Relationship",
+      "type": "object",
+      "required": [
+        "arguments",
+        "column_mapping",
+        "relationship_type",
+        "target_collection"
+      ],
+      "properties": {
+        "column_mapping": {
+          "description": "A mapping between columns on the source collection to columns on the target collection",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "relationship_type": {
+          "$ref": "#/definitions/RelationshipType"
+        },
+        "target_collection": {
+          "description": "The name of a collection",
+          "type": "string"
+        },
+        "arguments": {
+          "description": "Values to be provided to any collection arguments",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/RelationshipArgument"
+          }
+        }
+      }
+    },
+    "RelationshipType": {
+      "title": "Relationship Type",
+      "type": "string",
+      "enum": [
+        "object",
+        "array"
+      ]
+    }
+  }
+}

--- a/crates/ndc-graphql/tests/query_builder.rs
+++ b/crates/ndc-graphql/tests/query_builder.rs
@@ -4,16 +4,20 @@ use common::{config::config_file::ServerConfigFile, schema_response::schema_resp
 use insta::{assert_json_snapshot, assert_snapshot, assert_yaml_snapshot, glob};
 use ndc_graphql::{
     connector::setup::GraphQLConnectorSetup,
-    query_builder::{build_mutation_document, build_query_document},
+    query_builder::{build_mutation_document, build_query_document, error::QueryBuilderError},
 };
-use ndc_sdk::models;
+use ndc_sdk::models::{self, Type};
 use schemars::schema_for;
-use std::{collections::HashMap, fs, path::PathBuf};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs,
+    path::PathBuf,
+};
 
 #[tokio::test]
 #[ignore]
 async fn update_json_schema() {
-    for config in ["config-1", "config-2", "config-3"] {
+    for config in ["config-1", "config-2", "config-3", "config-4"] {
         fs::write(
             format!("./tests/{config}/queries/_query_request.schema.json"),
             serde_json::to_string_pretty(&schema_for!(models::QueryRequest))
@@ -75,6 +79,21 @@ async fn test_build_graphql_query() {
 }
 
 #[tokio::test]
+async fn test_build_graphql_query_polymorphic() {
+    let configuration = read_configuration("config-4").await;
+    let request = fs::read_to_string("./tests/config-4/queries/01_polymorphic_query.request.json")
+        .expect("Should be able to read file");
+    let request: models::QueryRequest =
+        serde_json::from_str(&request).expect("Should be valid request json");
+    let operation = build_query_document(&request, &configuration)
+        .expect("Should sucessfully build query document");
+
+    assert_snapshot!("Polymorphic Query String", operation.query);
+    assert_json_snapshot!("Polymorphic Variables", operation.variables);
+    assert_yaml_snapshot!("Polymorphic Headers", operation.headers);
+}
+
+#[tokio::test]
 async fn test_build_graphql_mutation() {
     for config in ["config-1", "config-2", "config-3"] {
         let configuration = read_configuration(config).await;
@@ -95,15 +114,124 @@ async fn test_build_graphql_mutation() {
 
 #[tokio::test]
 async fn test_generated_schema() {
-    for config in ["config-1", "config-2", "config-3"] {
+    for config in ["config-1", "config-2", "config-3", "config-4"] {
         let configuration = read_configuration(config).await;
         let schema = schema_response(
             &configuration.schema,
             &configuration.request,
             &configuration.response,
         );
+        assert_schema_references_resolve(&schema);
         assert_yaml_snapshot!(format!("{config} NDC Schema"), schema);
     }
+}
+
+#[tokio::test]
+async fn test_polymorphic_selection_errors() {
+    let configuration = read_configuration("config-4").await;
+
+    let unknown_variant =
+        query_request_with_polymorphic_field("on_DoesNotExist", None, nested_object_field("relId"));
+    assert!(
+        matches!(
+            build_query_document(&unknown_variant, &configuration),
+            Err(QueryBuilderError::PolymorphicFieldNotFound { .. })
+        ),
+        "unknown variant fields should fail with PolymorphicFieldNotFound"
+    );
+
+    let missing_selection =
+        query_request_with_polymorphic_field("on_PersonRelationship", None, None);
+    assert!(
+        matches!(
+            build_query_document(&missing_selection, &configuration),
+            Err(QueryBuilderError::PolymorphicFieldMissingSelection { .. })
+        ),
+        "variant fields without nested selection should fail with PolymorphicFieldMissingSelection"
+    );
+
+    let variant_with_arguments = query_request_with_polymorphic_field(
+        "on_PersonRelationship",
+        Some(BTreeMap::from([(
+            "ignored".into(),
+            models::Argument::Literal {
+                value: serde_json::json!(1),
+            },
+        )])),
+        nested_object_field("relId"),
+    );
+    assert!(
+        matches!(
+            build_query_document(&variant_with_arguments, &configuration),
+            Err(QueryBuilderError::PolymorphicFieldArgumentsNotSupported { .. })
+        ),
+        "variant fields with arguments should fail with PolymorphicFieldArgumentsNotSupported"
+    );
+
+    let typename_with_arguments = query_request_with_polymorphic_field(
+        "__typename",
+        Some(BTreeMap::from([(
+            "ignored".into(),
+            models::Argument::Literal {
+                value: serde_json::json!(1),
+            },
+        )])),
+        None,
+    );
+    assert!(
+        matches!(
+            build_query_document(&typename_with_arguments, &configuration),
+            Err(QueryBuilderError::TypenameArgumentsNotSupported { .. })
+        ),
+        "__typename with arguments should fail with TypenameArgumentsNotSupported"
+    );
+
+    let common_field_under_variant = query_request_with_polymorphic_field(
+        "on_PersonRelationship",
+        None,
+        nested_object_field("relId"),
+    );
+    assert!(
+        matches!(
+            build_query_document(&common_field_under_variant, &configuration),
+            Err(QueryBuilderError::ObjectFieldNotFound { .. })
+        ),
+        "common interface fields should not be selectable under on_<Type> variants"
+    );
+}
+
+#[tokio::test]
+async fn test_polymorphic_selection_alias_supported() {
+    let configuration = read_configuration("config-4").await;
+
+    let mut request = query_request_with_polymorphic_field(
+        "on_PersonRelationship",
+        None,
+        nested_object_field("personName"),
+    );
+    rename_polymorphic_variant_alias(&mut request, "on_PersonRelationship", "onPerson");
+
+    let operation = build_query_document(&request, &configuration)
+        .expect("aliased polymorphic selections should build");
+
+    assert!(
+        operation.query.contains("... on PersonRelationship"),
+        "expected inline fragment for aliased polymorphic field"
+    );
+}
+
+#[tokio::test]
+async fn test_interface_common_field_supported() {
+    let configuration = read_configuration("config-4").await;
+    let request = query_request_with_polymorphic_field("relId", None, None);
+
+    let operation = build_query_document(&request, &configuration)
+        .expect("interface common field should build");
+
+    assert!(
+        operation.query.contains("relationship {\n      relId"),
+        "expected direct interface field selection"
+    );
 }
 
 #[test]
@@ -118,4 +246,187 @@ fn configuration_schema() {
         serde_json::to_string_pretty(&schema_for!(ServerConfigFile))
             .expect("Should serialize schema to json")
     );
+}
+
+fn assert_schema_references_resolve(schema: &models::SchemaResponse) {
+    for (object_name, object_type) in &schema.object_types {
+        for (field_name, field) in &object_type.fields {
+            assert_type_resolves(
+                &field.r#type,
+                &schema.object_types,
+                &schema.scalar_types,
+                &format!("{object_name}.{field_name}"),
+            );
+        }
+    }
+
+    for function in &schema.functions {
+        for (argument_name, argument) in &function.arguments {
+            assert_type_resolves(
+                &argument.argument_type,
+                &schema.object_types,
+                &schema.scalar_types,
+                &format!("function {} argument {}", function.name, argument_name),
+            );
+        }
+        assert_type_resolves(
+            &function.result_type,
+            &schema.object_types,
+            &schema.scalar_types,
+            &format!("function {} result", function.name),
+        );
+    }
+
+    for procedure in &schema.procedures {
+        for (argument_name, argument) in &procedure.arguments {
+            assert_type_resolves(
+                &argument.argument_type,
+                &schema.object_types,
+                &schema.scalar_types,
+                &format!("procedure {} argument {}", procedure.name, argument_name),
+            );
+        }
+        assert_type_resolves(
+            &procedure.result_type,
+            &schema.object_types,
+            &schema.scalar_types,
+            &format!("procedure {} result", procedure.name),
+        );
+    }
+}
+
+fn assert_type_resolves(
+    ndc_type: &Type,
+    object_types: &BTreeMap<models::ObjectTypeName, models::ObjectType>,
+    scalar_types: &BTreeMap<models::ScalarTypeName, models::ScalarType>,
+    context: &str,
+) {
+    match ndc_type {
+        Type::Named { name } => assert!(
+            object_types.contains_key(name.as_str()) || scalar_types.contains_key(name.as_str()),
+            "unresolved NDC type {name} referenced by {context}"
+        ),
+        Type::Nullable { underlying_type } => {
+            assert_type_resolves(underlying_type, object_types, scalar_types, context)
+        }
+        Type::Array { element_type } => {
+            assert_type_resolves(element_type, object_types, scalar_types, context)
+        }
+        Type::Predicate { object_type_name } => assert!(
+            object_types.contains_key(object_type_name),
+            "unresolved predicate object type {object_type_name} referenced by {context}"
+        ),
+    }
+}
+
+fn query_request_with_polymorphic_field(
+    field_name: &str,
+    arguments: Option<BTreeMap<models::ArgumentName, models::Argument>>,
+    fields: Option<models::NestedField>,
+) -> models::QueryRequest {
+    let mut relationship_fields = indexmap::IndexMap::new();
+    relationship_fields.insert(
+        field_name.into(),
+        models::Field::Column {
+            column: field_name.into(),
+            fields,
+            arguments: arguments.unwrap_or_default(),
+        },
+    );
+
+    models::QueryRequest {
+        collection: "getAccountById".into(),
+        query: models::Query {
+            aggregates: None,
+            fields: Some(indexmap::IndexMap::from([(
+                "__value".into(),
+                models::Field::Column {
+                    column: "__value".into(),
+                    fields: Some(models::NestedField::Object(models::NestedObject {
+                        fields: indexmap::IndexMap::from([(
+                            "relationship".into(),
+                            models::Field::Column {
+                                column: "relationship".into(),
+                                fields: Some(models::NestedField::Object(models::NestedObject {
+                                    fields: relationship_fields,
+                                })),
+                                arguments: BTreeMap::new(),
+                            },
+                        )]),
+                    })),
+                    arguments: BTreeMap::new(),
+                },
+            )])),
+            limit: None,
+            offset: None,
+            order_by: None,
+            predicate: None,
+            groups: None,
+        },
+        arguments: BTreeMap::from([(
+            "id".into(),
+            models::Argument::Literal {
+                value: serde_json::json!("acct-1"),
+            },
+        )]),
+        collection_relationships: BTreeMap::new(),
+        variables: None,
+        request_arguments: None,
+    }
+}
+
+fn nested_object_field(field_name: &str) -> Option<models::NestedField> {
+    Some(models::NestedField::Object(models::NestedObject {
+        fields: indexmap::IndexMap::from([(
+            field_name.into(),
+            models::Field::Column {
+                column: field_name.into(),
+                fields: None,
+                arguments: BTreeMap::new(),
+            },
+        )]),
+    }))
+}
+
+fn rename_polymorphic_variant_alias(
+    request: &mut models::QueryRequest,
+    old_alias: &str,
+    new_alias: &str,
+) {
+    let root_field = request
+        .query
+        .fields
+        .as_mut()
+        .and_then(|fields| fields.get_mut("__value"))
+        .expect("request should contain __value");
+
+    let models::Field::Column {
+        fields: Some(models::NestedField::Object(root_object)),
+        ..
+    } = root_field
+    else {
+        panic!("__value should contain an object selection");
+    };
+
+    let relationship_field = root_object
+        .fields
+        .get_mut("relationship")
+        .expect("request should contain relationship field");
+
+    let models::Field::Column {
+        fields: Some(models::NestedField::Object(relationship_object)),
+        ..
+    } = relationship_field
+    else {
+        panic!("relationship field should contain an object selection");
+    };
+
+    let old_alias: models::FieldName = old_alias.into();
+    let new_alias: models::FieldName = new_alias.into();
+
+    let field = relationship_object
+        .fields
+        .swap_remove(&old_alias)
+        .expect("request should contain old polymorphic alias");
+    relationship_object.fields.insert(new_alias, field);
 }

--- a/crates/ndc-graphql/tests/snapshots/query_builder__Headers@06_scalar_coercion.request.json.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__Headers@06_scalar_coercion.request.json.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ndc-graphql/tests/query_builder.rs
+assertion_line: 76
+expression: operation.headers
+input_file: crates/ndc-graphql/tests/config-1/queries/06_scalar_coercion.request.json
+---
+Authorization: Bearer <token>

--- a/crates/ndc-graphql/tests/snapshots/query_builder__Polymorphic Headers.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__Polymorphic Headers.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ndc-graphql/tests/query_builder.rs
+expression: operation.headers
+---
+{}

--- a/crates/ndc-graphql/tests/snapshots/query_builder__Polymorphic Query String.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__Polymorphic Query String.snap
@@ -1,0 +1,26 @@
+---
+source: crates/ndc-graphql/tests/query_builder.rs
+assertion_line: 91
+expression: operation.query
+---
+query($arg_1_id: ID!) {
+  __value: getAccountById(id: $arg_1_id) {
+    id
+    relationship {
+      __typename
+      relId
+      ... on PersonRelationship {
+        personName
+      }
+      ... on OrganizationRelationship {
+        orgName
+      }
+    }
+    altRelationship {
+      __typename
+      ... on PersonRelationship {
+        relId
+      }
+    }
+  }
+}

--- a/crates/ndc-graphql/tests/snapshots/query_builder__Polymorphic Variables.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__Polymorphic Variables.snap
@@ -1,0 +1,7 @@
+---
+source: crates/ndc-graphql/tests/query_builder.rs
+expression: operation.variables
+---
+{
+  "arg_1_id": "acct-1"
+}

--- a/crates/ndc-graphql/tests/snapshots/query_builder__Query String@06_scalar_coercion.request.json.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__Query String@06_scalar_coercion.request.json.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ndc-graphql/tests/query_builder.rs
+assertion_line: 74
+expression: operation.query
+input_file: crates/ndc-graphql/tests/config-1/queries/06_scalar_coercion.request.json
+---
+query($arg_1_limit: Int, $arg_2_where: Album_bool_exp) {
+  __value: Album(limit: $arg_1_limit, where: $arg_2_where) {
+    AlbumId
+    Title
+  }
+}

--- a/crates/ndc-graphql/tests/snapshots/query_builder__Variables@06_scalar_coercion.request.json.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__Variables@06_scalar_coercion.request.json.snap
@@ -1,0 +1,14 @@
+---
+source: crates/ndc-graphql/tests/query_builder.rs
+assertion_line: 75
+expression: operation.variables
+input_file: crates/ndc-graphql/tests/config-1/queries/06_scalar_coercion.request.json
+---
+{
+  "arg_1_limit": 20,
+  "arg_2_where": {
+    "AlbumId": {
+      "_gt": 5
+    }
+  }
+}

--- a/crates/ndc-graphql/tests/snapshots/query_builder__config-4 NDC Schema.snap
+++ b/crates/ndc-graphql/tests/snapshots/query_builder__config-4 NDC Schema.snap
@@ -1,0 +1,169 @@
+---
+source: crates/ndc-graphql/tests/query_builder.rs
+assertion_line: 125
+expression: schema
+---
+scalar_types:
+  ID:
+    representation:
+      type: string
+    aggregate_functions: {}
+    comparison_operators: {}
+    extraction_functions: {}
+  String:
+    representation:
+      type: string
+    aggregate_functions: {}
+    comparison_operators: {}
+    extraction_functions: {}
+  _HeaderMap:
+    representation:
+      type: json
+    aggregate_functions: {}
+    comparison_operators: {}
+    extraction_functions: {}
+object_types:
+  Account:
+    fields:
+      altRelationship:
+        type:
+          type: nullable
+          underlying_type:
+            type: named
+            name: PartyRelationshipUnion
+      id:
+        type:
+          type: named
+          name: ID
+      relationship:
+        type:
+          type: named
+          name: PartyAccountRelationship
+    foreign_keys: {}
+  OrganizationRelationship:
+    fields:
+      orgName:
+        type:
+          type: nullable
+          underlying_type:
+            type: named
+            name: String
+      relId:
+        type:
+          type: named
+          name: ID
+    foreign_keys: {}
+  PartyAccountRelationship:
+    fields:
+      __typename:
+        description: Concrete GraphQL type name for polymorphic type PartyAccountRelationship
+        type:
+          type: named
+          name: String
+      on_OrganizationRelationship:
+        description: Fields available when runtime type is OrganizationRelationship
+        type:
+          type: nullable
+          underlying_type:
+            type: named
+            name: PartyAccountRelationshipOnOrganizationRelationship
+      on_PersonRelationship:
+        description: Fields available when runtime type is PersonRelationship
+        type:
+          type: nullable
+          underlying_type:
+            type: named
+            name: PartyAccountRelationshipOnPersonRelationship
+      relId:
+        type:
+          type: named
+          name: ID
+    foreign_keys: {}
+  PartyAccountRelationshipOnOrganizationRelationship:
+    description: Fields available only when runtime type is OrganizationRelationship for polymorphic type PartyAccountRelationship
+    fields:
+      orgName:
+        type:
+          type: nullable
+          underlying_type:
+            type: named
+            name: String
+    foreign_keys: {}
+  PartyAccountRelationshipOnPersonRelationship:
+    description: Fields available only when runtime type is PersonRelationship for polymorphic type PartyAccountRelationship
+    fields:
+      personName:
+        type:
+          type: nullable
+          underlying_type:
+            type: named
+            name: String
+    foreign_keys: {}
+  PartyRelationshipUnion:
+    fields:
+      __typename:
+        description: Concrete GraphQL type name for polymorphic type PartyRelationshipUnion
+        type:
+          type: named
+          name: String
+      on_OrganizationRelationship:
+        description: Fields available when runtime type is OrganizationRelationship
+        type:
+          type: nullable
+          underlying_type:
+            type: named
+            name: OrganizationRelationship
+      on_PersonRelationship:
+        description: Fields available when runtime type is PersonRelationship
+        type:
+          type: nullable
+          underlying_type:
+            type: named
+            name: PersonRelationship
+    foreign_keys: {}
+  PersonRelationship:
+    fields:
+      personName:
+        type:
+          type: nullable
+          underlying_type:
+            type: named
+            name: String
+      relId:
+        type:
+          type: named
+          name: ID
+    foreign_keys: {}
+collections: []
+functions:
+  - name: getAccountById
+    arguments:
+      id:
+        type:
+          type: named
+          name: ID
+    result_type:
+      type: nullable
+      underlying_type:
+        type: named
+        name: Account
+procedures: []
+capabilities: ~
+request_arguments:
+  query_arguments:
+    headers:
+      description: Headers to be merged into original request headers of graphql requests
+      type:
+        type: nullable
+        underlying_type:
+          type: named
+          name: _HeaderMap
+  mutation_arguments:
+    headers:
+      description: Headers to be merged into original request headers of graphql requests
+      type:
+        type: nullable
+        underlying_type:
+          type: named
+          name: _HeaderMap
+  relational_query_arguments: {}


### PR DESCRIPTION
## Summary

Self-hosted customers often use organization-signed certificates which are not supported when using `rustls-tls` (unlike `native-tls` which picks up system SSL environment variables). This change adds support for custom CA certificates and optionally disabling TLS verification entirely.

We read these environment variables directly from the OS rather than through connector configuration, as TLS settings are primarily an infrastructure concern.

## Environment Variables

| Variable | Description |
|----------|-------------|
| `GRAPHQL_CA_CERT_FILE` | Path to a single PEM-encoded CA certificate file |
| `GRAPHQL_CA_CERT_DIR` | Directory containing PEM-encoded CA certificates (`.pem`, `.crt`, `.cer`) |
| `GRAPHQL_INSECURE_SKIP_TLS_VERIFY` | Set to `true` or `1` to disable TLS verification (dangerous, for dev/testing only) |

**Notes:**
- `GRAPHQL_CA_CERT_FILE` and `GRAPHQL_CA_CERT_DIR` can be used together (certificates are combined)
- `GRAPHQL_INSECURE_SKIP_TLS_VERIFY` takes precedence and skips all CA cert logic when enabled

## Changes

- Added `rustls-pemfile` dependency for parsing PEM certificates
- Added `tracing` dependency for logging certificate loading info/warnings
- Updated `get_http_client()` to configure TLS based on environment variables
